### PR TITLE
Add custom-tokenizer Discord bot example

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,26 @@
+# Environment configuration for the Discord chatbot
+# Replace the placeholder values with your actual tokens.
+
+# Example single bot token
+# DISCORD_TOKEN=YOUR_BOT_TOKEN
+
+# Example sibling tokens (comma separated)
+# DISCORD_TOKENS=TOKEN_FOR_VIVI,TOKEN_FOR_VEX
+
+# Optional sibling names
+BOT_SIBLINGS=Vivi,Vex
+
+# Personality prompts
+BOT_PERSONALITY=You are an entertaining assistant.
+# BOT_PERSONALITY_VIVI=Cheerful and upbeat.
+# BOT_PERSONALITY_VEX=Sarcastic and witty.
+
+# Voice options
+ENABLE_TTS=true
+TTS_LANG=en
+STT_LANG=en-US
+
+# Paths for local models
+MODEL_PATH=markov_model.pkl
+LSTM_MODEL_PATH=lstm_model.h5
+LSTM_VOCAB_PATH=lstm_vocab.pkl

--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,11 @@
 # Example environment configuration for the Discord chatbot
-# Copy this file to `.env` and replace the placeholder values.
-
-# Discord bot tokens
-# Set `DISCORD_TOKEN` for a single bot, or `DISCORD_TOKENS` for multiple bots.
-DISCORD_TOKEN=
-# DISCORD_TOKENS=TOKEN_FOR_VIVI,TOKEN_FOR_VEX
+# Copy this file to `.env` and adjust the settings as needed.
+#
+# Note: Discord tokens are intentionally omitted here for security.
+# Set them in your shell before launching the bot:
+#   export DISCORD_TOKEN=YOUR_TOKEN
+#   # or
+#   export DISCORD_TOKENS=TOKEN_FOR_VIVI,TOKEN_FOR_VEX
 
 # Optional sibling names (comma-separated)
 BOT_SIBLINGS=Vivi,Vex

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# Example environment configuration for the Discord chatbot
+# Copy this file to `.env` and replace the placeholder values.
+
+# Discord bot tokens
+# Set `DISCORD_TOKEN` for a single bot, or `DISCORD_TOKENS` for multiple bots.
+DISCORD_TOKEN=
+# DISCORD_TOKENS=TOKEN_FOR_VIVI,TOKEN_FOR_VEX
+
+# Optional sibling names (comma-separated)
+BOT_SIBLINGS=Vivi,Vex
+
+# Personalities
+BOT_PERSONALITY=You are an entertaining assistant.
+# BOT_PERSONALITY_VIVI=Cheerful and upbeat.
+# BOT_PERSONALITY_VEX=Sarcastic and witty.
+
+# Voice options
+ENABLE_TTS=true
+TTS_LANG=en
+STT_LANG=en-US
+
+# Paths for local models
+MODEL_PATH=markov_model.pkl
+LSTM_MODEL_PATH=lstm_model.h5
+LSTM_VOCAB_PATH=lstm_vocab.pkl

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+*.sqlite3
+*.db
+*.log

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ The bot is implemented with `discord.py` and aims to be extensible for
 additional features such as moderation or logging. By default it tries to be
 generally entertaining in its responses.
 
+The included `call_ai_model` function does **not** use ChatGPT or any external
+service—it simply echoes the prompt. You are encouraged to replace it with your
+own model integration so the bot can run entirely on your own AI stack.
+
 ## Architecture Overview
 
 1. **Message Reception**: The bot listens to Discord events using
@@ -44,7 +48,7 @@ and make sure to follow Discord's terms of service when deploying a bot.
 
 ```bash
 # Install dependencies
-pip install discord.py gTTS
+pip install -r requirements.txt
 # On Linux you may need the `ffmpeg` package for voice playback
 
 # Set the Discord token in the environment (single bot)

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ export BOT_PERSONALITY="You are an entertaining assistant."
 export BOT_SIBLINGS="Vivi,Vex"
 
 # You can also place these variables in a `.env` file and `source .env`
-# before launching the bot. A sample `.env.example` is included.
+# before launching the bot. The sample `.env.example` lists common
+# options except the Discord tokens, which you should export separately.
 
 # Run the bot
 python -m bot.bot

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ export BOT_SIBLINGS="Vivi,Vex"
 python -m bot.bot
 ```
 
-The bot supports simple slash-style commands like `/ping`, `/help`, `/tictactoe`, `/rps`, and history commands in
+The bot supports simple slash-style commands like `/ping`, `/help`, `/tictactoe`, `/rps`, `/converse`, and history commands in
  addition to responding when it is mentioned by name or `@`. It can also join a voice channel and play a local audio file.
 
 ## Customizing the Tokenizer
@@ -174,6 +174,7 @@ This example demonstrates additional features beyond simple tokenization:
 - **Voice Transcription**: Attach an audio file and use `/transcribe` to convert speech to text.
 - **Cookies**: Server owners can gift the bot happiness cookies via `/giftcookies`.
 - **Rewards**: Win games to earn reward points and view them with `/rewards`.
+- **Sibling Chat**: Use `/converse` to watch the sibling bots talk to each other for a few rounds.
 - **Deep Training Command**: Kick off LSTM training from Discord with `/deeptrain`.
 - **Language Filter**: The bot allows mild swearing but will replace any blocked terms with `[filtered]`.
 - **Entertaining Personality**: Responses aim to be playful and amusing.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,18 @@ python -m bot.train_lstm
 If these files exist the bot will load the LSTM model instead of the Markov
 chain when generating replies.
 
+### Deep Training from Discord
+
+To retrain the LSTM model without leaving Discord, run the `/deeptrain` command
+in any channel the bot can access:
+
+```bash
+/deeptrain
+```
+
+This invokes the same process as running `python -m bot.train_lstm` locally and
+reloads the updated model when finished.
+
 ## Extensibility
 
 The current implementation is intentionally lightweight. You can add more
@@ -153,6 +165,7 @@ This example demonstrates additional features beyond simple tokenization:
 - **Voice Transcription**: Attach an audio file and use `/transcribe` to convert speech to text.
 - **Cookies**: Server owners can gift the bot happiness cookies via `/giftcookies`.
 - **Rewards**: Win games to earn reward points and view them with `/rewards`.
+- **Deep Training Command**: Kick off LSTM training from Discord with `/deeptrain`.
 - **Language Filter**: The bot allows mild swearing but will replace any blocked terms with `[filtered]`.
 - **Entertaining Personality**: Responses aim to be playful and amusing.
 - **Learning Mode**: The bot stores its replies as training data and even

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ export BOT_PERSONALITY="You are an entertaining assistant."
 # Optional comma-separated names for two siblings
 export BOT_SIBLINGS="Vivi,Vex"
 
+# You can also place these variables in a `.env` file and `source .env`
+# before launching the bot. A sample `.env.example` is included.
+
 # Run the bot
 python -m bot.bot
 # Make sure to run this command from the repository root. Running it from

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ python -m bot.bot
 ```
 
 When both bots share a channel they can hold short conversations without user input.
+If multiple bots run at once each one uses a prefix based on its name, for
+example `/vivi help` or `/vex ping`. With a single bot the prefix is simply `/`.
 
 The bot supports simple slash-style commands like `/ping`, `/help`, `/tictactoe`, `/rps`, `/converse`, and history commands in
  addition to responding when it is mentioned by name or `@`. It can also join a voice channel and play a local audio file.
@@ -185,6 +187,7 @@ This example demonstrates additional features beyond simple tokenization:
 - **Voice Recognition**: Register your voice with `/registervoice`. When anyone posts an audio attachment the bot automatically compares it against registered samples and announces who it sounds like.
 - **Cookies**: Server owners can gift the bot happiness cookies via `/giftcookies`.
 - **Rewards**: Win games to earn reward points and view them with `/rewards`.
+- **Relationships**: Each user has a 1-100 relationship score with every bot and can check it via `/relationship`.
 - **Sibling Chat**: Use `/converse` to watch the sibling bots talk to each other for a few rounds. They will also naturally reply to one another when sharing a channel, up to a few messages each time.
 - **Deep Training Command**: Kick off LSTM training from Discord with `/deeptrain`.
 - **Language Filter**: The bot allows mild swearing but will replace any blocked terms with `[filtered]`.
@@ -278,6 +281,11 @@ Check the current cookie count with `/cookies`.
 
 When you win certain games (TicTacToe, RPS, GuessNumber, Hangman) you earn
 reward points. View your balance with `/rewards`.
+
+## Relationships
+
+Every user maintains a relationship score with each bot between 1 and 100.
+The score slowly increases as you chat. Check it anytime with `/relationship`.
 
 ## Logging and Dialogue Memory
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,236 @@
-# repo
+# Custom Tokenizer Discord Chatbot
+
+This repository contains a minimal example of a Discord chatbot that uses a
+custom tokenizer. You can easily swap in your own tokenizer and AI backend.
+The bot is implemented with `discord.py` and aims to be extensible for
+additional features such as moderation or logging. By default it tries to be
+generally entertaining in its responses.
+
+## Architecture Overview
+
+1. **Message Reception**: The bot listens to Discord events using
+   `discord.py`. When a new message arrives, it checks whether the message is a
+   command or regular text.
+2. **Tokenization**: Incoming text is passed through a configurable tokenizer
+   (`bot/tokenizer.py`). You may replace this with your own implementation.
+3. **AI Model Call**: The processed text is sent to the AI backend
+   (`call_ai_model`). This function can call any model API (OpenAI, local
+   Llama, etc.) and returns the model's response.
+4. **Response Delivery**: The response text is posted back to the Discord
+   channel. Basic conversation history is stored per channel to maintain
+   context.
+
+```
+Discord -> Tokenizer -> AI Model -> Discord
+```
+
+## Credits
+
+This project was inspired by Vedal's **Neuro-sama**. The code here is a small
+educational example and not affiliated with the original creator. Feel free to
+extend it with your own ideas.
+
+## Future Work
+
+Possible extensions include adding real language model calls, more sophisticated
+game logic, and richer voice synthesis. Contributions are welcome.
+
+---
+
+This repository is provided for demonstration purposes. Use at your own risk
+and make sure to follow Discord's terms of service when deploying a bot.
+
+## Sample Usage
+
+```bash
+# Install dependencies
+pip install discord.py gTTS
+# On Linux you may need the `ffmpeg` package for voice playback
+
+# Set the Discord token in the environment
+export DISCORD_TOKEN="YOUR_BOT_TOKEN"
+
+# Optionally set a personality prompt
+export BOT_PERSONALITY="You are an entertaining assistant."
+# Optional comma-separated names for two siblings
+export BOT_SIBLINGS="Alpha,Beta"
+
+# Run the bot
+python -m bot.bot
+```
+
+The bot supports simple slash-style commands like `/ping`, `/help`, `/tictactoe`, `/rps`, and history commands in
+ addition to responding when it is mentioned by name or `@`. It can also join a voice channel and play a local audio file.
+
+## Customizing the Tokenizer
+
+Edit `bot/tokenizer.py` or create your own tokenizer class with `encode` and
+`decode` methods. For example, you could implement emoji-based tokenization or
+integrate a third-party library.
+
+Update `bot/bot.py` to pass your tokenizer instance when creating the
+`ChatBot` cog:
+
+```python
+from my_tokenizer import MyTokenizer
+bot.add_cog(ChatBot(bot, tokenizer=MyTokenizer()))
+```
+
+## Changing the AI Backend
+
+The `call_ai_model` function in `bot/bot.py` is a placeholder. Replace its
+implementation with a call to your preferred model. For example, to use the
+OpenAI API:
+
+```python
+import openai
+
+async def call_ai_model(prompt: str) -> str:
+    response = openai.ChatCompletion.create(
+        model="gpt-4",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response["choices"][0]["message"]["content"]
+```
+
+If you want to swap in a local model such as Llama, you can modify the
+function to invoke that model instead.
+
+## Extensibility
+
+The current implementation is intentionally lightweight. You can add more
+`discord.py` cogs for features like moderation, logging, or additional
+commands. Because the tokenizer and AI backend are decoupled, it is easy to
+experiment with new approaches without rewriting the bot.
+
+## Extended Capabilities
+
+This example demonstrates additional features beyond simple tokenization:
+
+- **Persistent Memory**: Conversation history is saved per channel using Python's `shelve` module so the bot remembers context across restarts.
+- **Training Samples**: Users can provide paired prompts and responses with the `/train` command to influence future replies.
+- **Automatic Learning**: Every conversation is stored as a new training pair so the bot gradually adapts.
+- **Thought Process**: Before calling the AI model the bot performs a lightweight reasoning step that can be customized.
+- **Math Mode**: Messages that contain arithmetic expressions are evaluated locally for quick answers.
+- **Tic‑Tac‑Toe**: The bot can host a game of tic‑tac‑toe between two users using the `/tictactoe` command.
+- **Rock Paper Scissors**: Challenge the bot with `/rps` and make moves with `/rpsmove`.
+- **History Commands**: Use `/history` to show recent conversation and `/clearhistory` to wipe it.
+- **Voice Chat**: Use `/join` and `/leave` to manage voice connections and `/play` to stream a local file.
+- **Cookies**: Server owners can gift the bot happiness cookies via `/giftcookies`.
+- **Rewards**: Win games to earn reward points and view them with `/rewards`.
+- **Language Filter**: The bot allows mild swearing but will replace any blocked terms with `[filtered]`.
+- **Entertaining Personality**: Responses aim to be playful and amusing.
+- **Learning Mode**: The bot stores its replies as training data and even
+  observes conversations between other users to expand its knowledge.
+- **Mentions**: It only answers when mentioned by name or via `@`, allowing it
+  to sit quietly until called upon.
+- **Sibling Personalities**: Two AI siblings can be configured with the
+  `BOT_SIBLINGS` environment variable (default `Alpha,Beta`). Each sibling can
+  have its own personality prompt using `BOT_PERSONALITY_ALPHA` and
+  `BOT_PERSONALITY_BETA`.
+
+These capabilities are intentionally simple but illustrate how the bot can be extended in many directions.
+
+### Configurable Thought Step
+
+The `think` method in `bot/bot.py` shows a basic chain‑of‑thought implementation. You can modify this function to add planning or tool use before the final model call.
+
+### Example Training
+
+```bash
+# Teach the bot a custom reply
+/train "Hello" "Hi there!"
+```
+
+Training samples are stored in the memory database and included in the prompt whenever the user message matches a trained example.
+
+## Voice Commands
+
+Use `/join` to have the bot connect to your current voice channel. `/play <file>` will play a local audio file and `/leave` disconnects the bot.
+
+## Moderating Language
+
+The bot's responses are passed through a small filter that replaces banned words with `[filtered]`. The list of blocked terms is defined in `bot/bot.py` and can be customized. Mild swearing such as "damn" or "shit" is allowed, but any slurs you add to the blocklist will be sanitized, e.g.:
+
+```
+shut up you stupid [filtered]
+```
+
+You can modify `allowed_cuss` and `blocked_words` in the `ChatBot` class to suit your own needs.
+
+## Running Tests
+
+Compile the modules to verify there are no syntax errors:
+
+```bash
+python -m py_compile \
+    bot/tokenizer.py bot/bot.py bot/memory.py bot/games.py \
+    bot/tts.py bot/game_ai.py bot/adventure.py bot/dialogue.py \
+    bot/logger.py bot/utils.py
+```
+
+## Text-to-Speech and DMs
+
+Set `ENABLE_TTS=true` to have the bot read its replies aloud in a voice channel
+using `gTTS`. Install the `gTTS` Python package and make sure `ffmpeg` is
+available. If a voice connection exists it will stream the generated audio and
+also send the text as a private message to the user who triggered it.
+
+## Guess Number Game
+
+Use `/guessnumber` to start a simple guessing game and `/guess` to make moves.
+
+## Hangman
+
+Start a hangman match with `/hangman`. Guess letters using `/hang` until you
+either reveal the word or run out of attempts.
+
+## Text Adventure
+
+Begin a mini text adventure with `/adventure` and interact using `/adv`.
+
+## Cookies and Rewards
+
+Server owners can boost the bot's happiness by gifting **cookies**:
+
+```bash
+/giftcookies 5
+```
+
+Check the current cookie count with `/cookies`.
+
+When you win certain games (TicTacToe, RPS, GuessNumber, Hangman) you earn
+reward points. View your balance with `/rewards`.
+
+## Logging and Dialogue Memory
+
+Every message and response is recorded to `bot.log` via the `Logger` class, and
+`DialogueMemory` keeps short histories per user for summaries.
+
+## Game AI Stub
+
+`bot/game_ai.py` contains a placeholder class for a separate AI model that could
+control in-game actions, mirroring how Neuro-sama relies on a dedicated system
+for gameplay.
+
+You can mimic Neuro-sama and her "Evil" twin by setting
+`BOT_SIBLINGS="Neuro,Evil"` and providing different personality prompts for each
+with `BOT_PERSONALITY_NEURO` and `BOT_PERSONALITY_EVIL`.
+
+## Inspiration from Neuro-sama
+
+The voice features are inspired by **Neuro-sama**, an AI VTuber created by
+`vedal987` that speaks with a high-pitched voice. Our bot can likewise speak in
+voice chat while also sending text responses.
+
+## Updated Tests
+
+Run compilation to ensure the new modules are error free:
+
+```bash
+python -m py_compile \
+    bot/tokenizer.py bot/bot.py bot/memory.py bot/games.py \
+    bot/tts.py bot/game_ai.py bot/adventure.py bot/dialogue.py \
+    bot/logger.py bot/utils.py
+```
+

--- a/README.md
+++ b/README.md
@@ -56,14 +56,23 @@ pip install -r requirements.txt
 # Set the Discord token in the environment (single bot)
 export DISCORD_TOKEN="YOUR_BOT_TOKEN"
 # Or run two sibling bots with separate tokens
-# export DISCORD_TOKENS="TOKEN_FOR_ALPHA,TOKEN_FOR_BETA"
+# export DISCORD_TOKENS="TOKEN_FOR_VIVI,TOKEN_FOR_VEX"
 
 # Optionally set a personality prompt
 export BOT_PERSONALITY="You are an entertaining assistant."
 # Optional comma-separated names for two siblings
-export BOT_SIBLINGS="Vivi,Beta"
+export BOT_SIBLINGS="Vivi,Vex"
 
 # Run the bot
+python -m bot.bot
+```
+
+For two sibling bots named **Vivi** and **Vex**, place both tokens in the
+`DISCORD_TOKENS` variable before running:
+
+```bash
+export DISCORD_TOKENS="TOKEN_FOR_VIVI,TOKEN_FOR_VEX"
+export BOT_SIBLINGS="Vivi,Vex"
 python -m bot.bot
 ```
 
@@ -173,10 +182,10 @@ This example demonstrates additional features beyond simple tokenization:
 - **Mentions**: It only answers when mentioned by name or via `@`, allowing it
   to sit quietly until called upon.
 - **Sibling Personalities**: Two AI siblings can be configured with the
-  `BOT_SIBLINGS` environment variable (default `Vivi,Beta`). Each sibling can
-  have its own personality prompt using `BOT_PERSONALITY_ALPHA` and
-  `BOT_PERSONALITY_BETA`. Provide matching tokens with
-  `DISCORD_TOKENS="TOKEN_FOR_ALPHA,TOKEN_FOR_BETA"` to run them as separate bot
+  `BOT_SIBLINGS` environment variable (default `Vivi,Vex`). Each sibling can
+  have its own personality prompt using `BOT_PERSONALITY_VIVI` and
+  `BOT_PERSONALITY_VEX`. Provide matching tokens with
+  `DISCORD_TOKENS="TOKEN_FOR_VIVI,TOKEN_FOR_VEX"` to run them as separate bot
   accounts from the same codebase.
 
 These capabilities are intentionally simple but illustrate how the bot can be extended in many directions.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ and make sure to follow Discord's terms of service when deploying a bot.
 # Install dependencies
 pip install -r requirements.txt
 # On Linux you may need the `ffmpeg` package for voice playback
+# Training the optional LSTM model requires the `tensorflow` package
 
 # Set the Discord token in the environment (single bot)
 export DISCORD_TOKEN="YOUR_BOT_TOKEN"
@@ -114,6 +115,19 @@ python -m bot.train_markov
 This generates `markov_model.pkl`, which `bot/bot.py` loads automatically.
 The model learns from the examples collected with `/train` and from observed
 conversations, so you can improve it over time.
+
+### Training a Small LSTM Model
+
+For a more capable local model you can train a small character-level LSTM.
+It learns from the same stored conversation pairs and saves a Keras model
+(`lstm_model.h5`) plus vocabulary file (`lstm_vocab.pkl`):
+
+```bash
+python -m bot.train_lstm
+```
+
+If these files exist the bot will load the LSTM model instead of the Markov
+chain when generating replies.
 
 ## Extensibility
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ This example demonstrates additional features beyond simple tokenization:
 - **History Commands**: Use `/history` to show recent conversation and `/clearhistory` to wipe it.
 - **Voice Chat**: Use `/join` and `/leave` to manage voice connections and `/play` to stream a local file.
 - **Voice Transcription**: Attach an audio file and use `/transcribe` to convert speech to text.
-- **Voice Recognition**: Register your voice with `/registervoice` and identify speakers with `/identifyvoice`.
+- **Voice Recognition**: Register your voice with `/registervoice`. When anyone posts an audio attachment the bot automatically compares it against registered samples and announces who it sounds like.
 - **Cookies**: Server owners can gift the bot happiness cookies via `/giftcookies`.
 - **Rewards**: Win games to earn reward points and view them with `/rewards`.
 - **Sibling Chat**: Use `/converse` to watch the sibling bots talk to each other for a few rounds. They will also naturally reply to one another when sharing a channel, up to a few messages each time.
@@ -216,7 +216,7 @@ Training samples are stored in the memory database and included in the prompt wh
 
 ## Voice Commands
 
-Use `/join` to have the bot connect to your current voice channel. `/play <file>` will play a local audio file and `/leave` disconnects the bot. Attach an audio file and use `/transcribe` to convert it to text. `/registervoice` saves your voice for recognition and `/identifyvoice` attempts to match a new sample to a registered user.
+Use `/join` to have the bot connect to your current voice channel. `/play <file>` will play a local audio file and `/leave` disconnects the bot. Attach an audio file and use `/transcribe` to convert it to text. After you register a sample with `/registervoice`, the bot will automatically try to recognize future audio attachments and mention who it thinks is speaking.
 
 ## Moderating Language
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,10 @@ and make sure to follow Discord's terms of service when deploying a bot.
 pip install discord.py gTTS
 # On Linux you may need the `ffmpeg` package for voice playback
 
-# Set the Discord token in the environment
+# Set the Discord token in the environment (single bot)
 export DISCORD_TOKEN="YOUR_BOT_TOKEN"
+# Or run two sibling bots with separate tokens
+# export DISCORD_TOKENS="TOKEN_FOR_ALPHA,TOKEN_FOR_BETA"
 
 # Optionally set a personality prompt
 export BOT_PERSONALITY="You are an entertaining assistant."
@@ -127,7 +129,9 @@ This example demonstrates additional features beyond simple tokenization:
 - **Sibling Personalities**: Two AI siblings can be configured with the
   `BOT_SIBLINGS` environment variable (default `Alpha,Beta`). Each sibling can
   have its own personality prompt using `BOT_PERSONALITY_ALPHA` and
-  `BOT_PERSONALITY_BETA`.
+  `BOT_PERSONALITY_BETA`. Provide matching tokens with
+  `DISCORD_TOKENS="TOKEN_FOR_ALPHA,TOKEN_FOR_BETA"` to run them as separate bot
+  accounts from the same codebase.
 
 These capabilities are intentionally simple but illustrate how the bot can be extended in many directions.
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ export BOT_SIBLINGS="Vivi,Vex"
 
 # Run the bot
 python -m bot.bot
+# Make sure to run this command from the repository root. Running it from
+# inside the `bot/` directory will cause an `ImportError` because the package
+# cannot be located.
 ```
 
 For two sibling bots named **Vivi** and **Vex**, place both tokens in the

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ The bot is implemented with `discord.py` and aims to be extensible for
 additional features such as moderation or logging. By default it tries to be
 generally entertaining in its responses.
 
-The included `call_ai_model` function does **not** use ChatGPT or any external
-service—it simply echoes the prompt. You are encouraged to replace it with your
-own model integration so the bot can run entirely on your own AI stack.
+The included `call_ai_model` function loads a tiny Markov chain model so the bot
+can operate without any external service. You may replace it with your own model
+integration so the bot can run entirely on your own AI stack.
 
 ## Architecture Overview
 
@@ -101,6 +101,19 @@ async def call_ai_model(prompt: str) -> str:
 
 If you want to swap in a local model such as Llama, you can modify the
 function to invoke that model instead.
+
+### Training the Sample Markov Model
+
+The repository includes a toy Markov chain implementation that can run
+without any external APIs. Train it using your stored conversation pairs:
+
+```bash
+python -m bot.train_markov
+```
+
+This generates `markov_model.pkl`, which `bot/bot.py` loads automatically.
+The model learns from the examples collected with `/train` and from observed
+conversations, so you can improve it over time.
 
 ## Extensibility
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ and make sure to follow Discord's terms of service when deploying a bot.
 # Install dependencies
 pip install -r requirements.txt
 # On Linux you may need the `ffmpeg` package for voice playback
+# Speech transcription via `/transcribe` requires the `SpeechRecognition` package
 # Training the optional LSTM model requires the `tensorflow` package
 
 # Set the Discord token in the environment (single bot)
@@ -149,6 +150,7 @@ This example demonstrates additional features beyond simple tokenization:
 - **Rock Paper Scissors**: Challenge the bot with `/rps` and make moves with `/rpsmove`.
 - **History Commands**: Use `/history` to show recent conversation and `/clearhistory` to wipe it.
 - **Voice Chat**: Use `/join` and `/leave` to manage voice connections and `/play` to stream a local file.
+- **Voice Transcription**: Attach an audio file and use `/transcribe` to convert speech to text.
 - **Cookies**: Server owners can gift the bot happiness cookies via `/giftcookies`.
 - **Rewards**: Win games to earn reward points and view them with `/rewards`.
 - **Language Filter**: The bot allows mild swearing but will replace any blocked terms with `[filtered]`.
@@ -181,7 +183,7 @@ Training samples are stored in the memory database and included in the prompt wh
 
 ## Voice Commands
 
-Use `/join` to have the bot connect to your current voice channel. `/play <file>` will play a local audio file and `/leave` disconnects the bot.
+Use `/join` to have the bot connect to your current voice channel. `/play <file>` will play a local audio file and `/leave` disconnects the bot. Attach an audio file and use `/transcribe` to convert it to text.
 
 ## Moderating Language
 
@@ -200,7 +202,7 @@ Compile the modules to verify there are no syntax errors:
 ```bash
 python -m py_compile \
     bot/tokenizer.py bot/bot.py bot/memory.py bot/games.py \
-    bot/tts.py bot/game_ai.py bot/adventure.py bot/dialogue.py \
+    bot/tts.py bot/stt.py bot/game_ai.py bot/adventure.py bot/dialogue.py \
     bot/logger.py bot/utils.py
 ```
 
@@ -210,6 +212,12 @@ Set `ENABLE_TTS=true` to have the bot read its replies aloud in a voice channel
 using `gTTS`. Install the `gTTS` Python package and make sure `ffmpeg` is
 available. If a voice connection exists it will stream the generated audio and
 also send the text as a private message to the user who triggered it.
+
+## Speech Recognition
+
+Install the `SpeechRecognition` Python package and use `/transcribe` with an
+audio attachment to convert speech into text. The bot uses the offline Sphinx
+engine by default.
 
 ## Guess Number Game
 
@@ -265,7 +273,7 @@ Run compilation to ensure the new modules are error free:
 ```bash
 python -m py_compile \
     bot/tokenizer.py bot/bot.py bot/memory.py bot/games.py \
-    bot/tts.py bot/game_ai.py bot/adventure.py bot/dialogue.py \
+    bot/tts.py bot/stt.py bot/game_ai.py bot/adventure.py bot/dialogue.py \
     bot/logger.py bot/utils.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ and make sure to follow Discord's terms of service when deploying a bot.
 pip install -r requirements.txt
 # On Linux you may need the `ffmpeg` package for voice playback
 # Speech transcription via `/transcribe` requires the `SpeechRecognition` package
+# Voice recognition needs the `librosa` and `soundfile` packages
 # Training the optional LSTM model requires the `tensorflow` package
 
 # Set the Discord token in the environment (single bot)
@@ -180,6 +181,7 @@ This example demonstrates additional features beyond simple tokenization:
 - **History Commands**: Use `/history` to show recent conversation and `/clearhistory` to wipe it.
 - **Voice Chat**: Use `/join` and `/leave` to manage voice connections and `/play` to stream a local file.
 - **Voice Transcription**: Attach an audio file and use `/transcribe` to convert speech to text.
+- **Voice Recognition**: Register your voice with `/registervoice` and identify speakers with `/identifyvoice`.
 - **Cookies**: Server owners can gift the bot happiness cookies via `/giftcookies`.
 - **Rewards**: Win games to earn reward points and view them with `/rewards`.
 - **Sibling Chat**: Use `/converse` to watch the sibling bots talk to each other for a few rounds. They will also naturally reply to one another when sharing a channel, up to a few messages each time.
@@ -214,7 +216,7 @@ Training samples are stored in the memory database and included in the prompt wh
 
 ## Voice Commands
 
-Use `/join` to have the bot connect to your current voice channel. `/play <file>` will play a local audio file and `/leave` disconnects the bot. Attach an audio file and use `/transcribe` to convert it to text.
+Use `/join` to have the bot connect to your current voice channel. `/play <file>` will play a local audio file and `/leave` disconnects the bot. Attach an audio file and use `/transcribe` to convert it to text. `/registervoice` saves your voice for recognition and `/identifyvoice` attempts to match a new sample to a registered user.
 
 ## Moderating Language
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ export BOT_SIBLINGS="Vivi,Vex"
 python -m bot.bot
 ```
 
+When both bots share a channel they can hold short conversations without user input.
+
 The bot supports simple slash-style commands like `/ping`, `/help`, `/tictactoe`, `/rps`, `/converse`, and history commands in
  addition to responding when it is mentioned by name or `@`. It can also join a voice channel and play a local audio file.
 
@@ -174,7 +176,7 @@ This example demonstrates additional features beyond simple tokenization:
 - **Voice Transcription**: Attach an audio file and use `/transcribe` to convert speech to text.
 - **Cookies**: Server owners can gift the bot happiness cookies via `/giftcookies`.
 - **Rewards**: Win games to earn reward points and view them with `/rewards`.
-- **Sibling Chat**: Use `/converse` to watch the sibling bots talk to each other for a few rounds.
+- **Sibling Chat**: Use `/converse` to watch the sibling bots talk to each other for a few rounds. They will also naturally reply to one another when sharing a channel, up to a few messages each time.
 - **Deep Training Command**: Kick off LSTM training from Discord with `/deeptrain`.
 - **Language Filter**: The bot allows mild swearing but will replace any blocked terms with `[filtered]`.
 - **Entertaining Personality**: Responses aim to be playful and amusing.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ export DISCORD_TOKEN="YOUR_BOT_TOKEN"
 # Optionally set a personality prompt
 export BOT_PERSONALITY="You are an entertaining assistant."
 # Optional comma-separated names for two siblings
-export BOT_SIBLINGS="Alpha,Beta"
+export BOT_SIBLINGS="Vivi,Beta"
 
 # Run the bot
 python -m bot.bot
@@ -173,7 +173,7 @@ This example demonstrates additional features beyond simple tokenization:
 - **Mentions**: It only answers when mentioned by name or via `@`, allowing it
   to sit quietly until called upon.
 - **Sibling Personalities**: Two AI siblings can be configured with the
-  `BOT_SIBLINGS` environment variable (default `Alpha,Beta`). Each sibling can
+  `BOT_SIBLINGS` environment variable (default `Vivi,Beta`). Each sibling can
   have its own personality prompt using `BOT_PERSONALITY_ALPHA` and
   `BOT_PERSONALITY_BETA`. Provide matching tokens with
   `DISCORD_TOKENS="TOKEN_FOR_ALPHA,TOKEN_FOR_BETA"` to run them as separate bot

--- a/bot/adventure.py
+++ b/bot/adventure.py
@@ -1,0 +1,91 @@
+from dataclasses import dataclass, field
+
+@dataclass
+class Room:
+    name: str
+    description: str
+    exits: dict[str, str]
+    items: list[str] = field(default_factory=list)
+
+@dataclass
+class Player:
+    location: str = 'start'
+    inventory: list[str] = field(default_factory=list)
+
+class AdventureGame:
+    """Very small text adventure with a few rooms."""
+
+    def __init__(self):
+        self.rooms = {
+            'start': Room(
+                name='start',
+                description='You are in a small room. Exits lead east and south.',
+                exits={'east': 'hall', 'south': 'closet'},
+                items=['key'],
+            ),
+            'hall': Room(
+                name='hall',
+                description='A long hallway. There is a locked door to the north.',
+                exits={'west': 'start', 'north': 'treasure'},
+            ),
+            'closet': Room(
+                name='closet',
+                description='A dusty closet filled with cobwebs.',
+                exits={'north': 'start'},
+            ),
+            'treasure': Room(
+                name='treasure',
+                description='A glittering treasure room!',
+                exits={'south': 'hall'},
+                items=['treasure'],
+            ),
+        }
+        self.player = Player()
+        self.game_over = False
+
+    def current_room(self) -> Room:
+        return self.rooms[self.player.location]
+
+    def look(self) -> str:
+        room = self.current_room()
+        desc = room.description
+        if room.items:
+            desc += '\nYou see: ' + ', '.join(room.items)
+        desc += '\nExits: ' + ', '.join(room.exits.keys())
+        return desc
+
+    def move(self, direction: str) -> str:
+        room = self.current_room()
+        if direction not in room.exits:
+            return 'You cannot go that way.'
+        dest = room.exits[direction]
+        if dest == 'treasure' and 'key' not in self.player.inventory:
+            return 'The door is locked.'
+        self.player.location = dest
+        if dest == 'treasure':
+            self.game_over = True
+            return 'You found the treasure and win!'
+        return self.look()
+
+    def take(self, item: str) -> str:
+        room = self.current_room()
+        if item not in room.items:
+            return 'There is no such item here.'
+        room.items.remove(item)
+        self.player.inventory.append(item)
+        return f'You picked up {item}.'
+
+    def handle_command(self, command: str) -> str:
+        parts = command.split()
+        if not parts:
+            return 'Try a command.'
+        action = parts[0].lower()
+        arg = parts[1] if len(parts) > 1 else ''
+        if action == 'look':
+            return self.look()
+        if action == 'move':
+            return self.move(arg)
+        if action == 'take':
+            return self.take(arg)
+        return 'Unknown command.'
+

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -70,7 +70,7 @@ class ChatBot(commands.Cog):
             "You are an entertaining and helpful assistant who may use mild swearing but never slurs."
         )
 
-        self.siblings = env_list("BOT_SIBLINGS", "Alpha,Beta")
+        self.siblings = env_list("BOT_SIBLINGS", "Vivi,Beta")
         self.sibling_personalities = {}
         for s in self.siblings:
             key = f"BOT_PERSONALITY_{s.upper()}"
@@ -528,7 +528,7 @@ def main():
             raise RuntimeError("DISCORD_TOKEN or DISCORD_TOKENS must be set")
         tokens = [token]
 
-    sibling_names = env_list("BOT_SIBLINGS", "Alpha,Beta")
+    sibling_names = env_list("BOT_SIBLINGS", "Vivi,Beta")
 
     async def runner():
         tasks = []

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -632,7 +632,8 @@ class ChatBot(commands.Cog):
 async def run_single(token: str, sibling: str | None = None, prefix: str = "/"):
     intents = discord.Intents.default()
     intents.message_content = True
-    bot = commands.Bot(command_prefix=prefix, intents=intents)
+    # Disable the default help command so our custom version can register
+    bot = commands.Bot(command_prefix=prefix, intents=intents, help_command=None)
     await bot.add_cog(ChatBot(bot, name=sibling))
 
     @bot.event

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -2,6 +2,7 @@ import os
 import ast
 import random
 import asyncio
+import tempfile
 import discord
 from discord.ext import commands
 
@@ -9,6 +10,7 @@ from .tokenizer import SimpleTokenizer
 from .memory import Memory
 from .games import TicTacToeGame, RockPaperScissorsGame, GuessNumberGame, HangmanGame
 from .tts import TextToSpeech
+from .stt import SpeechToText
 from .game_ai import GameAI
 from .adventure import AdventureGame
 from .dialogue import DialogueMemory
@@ -90,6 +92,7 @@ class ChatBot(commands.Cog):
         # Voice and TTS
         self.enable_tts = env_bool("ENABLE_TTS", True)
         self.tts = TextToSpeech(lang=os.getenv("TTS_LANG", "en"))
+        self.stt = SpeechToText(lang=os.getenv("STT_LANG", "en-US"))
 
         # Logger and dialogue memory
         self.logger = Logger()
@@ -235,7 +238,7 @@ class ChatBot(commands.Cog):
     @commands.command()
     async def help(self, ctx: commands.Context):
         await ctx.send(
-            "Available commands: /ping, /help, /train, /tictactoe, /move, /rps, /rpsmove, /guessnumber, /guess, /hangman, /hang, /adventure, /adv, /dm, /history, /clearhistory, /giftcookies, /cookies, /rewards, /join, /leave, /play"
+            "Available commands: /ping, /help, /train, /tictactoe, /move, /rps, /rpsmove, /guessnumber, /guess, /hangman, /hang, /adventure, /adv, /dm, /history, /clearhistory, /giftcookies, /cookies, /rewards, /join, /leave, /play, /transcribe"
         )
 
     @commands.command()
@@ -475,6 +478,23 @@ class ChatBot(commands.Cog):
         source = discord.FFmpegPCMAudio(file_path)
         vc.play(source)
         await ctx.send(f"Playing {file_path}.")
+
+    @commands.command()
+    async def transcribe(self, ctx: commands.Context):
+        """Transcribe an attached audio file."""
+        if not ctx.message.attachments:
+            await ctx.send("Attach an audio file to transcribe.")
+            return
+        attachment = ctx.message.attachments[0]
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            await attachment.save(tmp.name)
+            path = tmp.name
+        text = self.stt.transcribe(path)
+        os.remove(path)
+        if text:
+            await ctx.send(f"Transcription: {text}")
+        else:
+            await ctx.send("Unable to transcribe the audio.")
 
 
 async def run_single(token: str, sibling: str | None = None):

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -198,6 +198,34 @@ class ChatBot(commands.Cog):
         if message.author != self.bot.user:
             self.last_messages[channel_id] = (message.author.id, message.content)
 
+        # Automatic voice recognition on audio attachments
+        audio_path = None
+        for a in message.attachments:
+            name = a.filename.lower()
+            if name.endswith((".wav", ".mp3", ".ogg", ".m4a", ".flac")):
+                with tempfile.NamedTemporaryFile(delete=False) as tmp:
+                    await a.save(tmp.name)
+                    audio_path = tmp.name
+                break
+        if audio_path:
+            sample = self.voice_recognizer.extract(audio_path)
+            os.remove(audio_path)
+            if self.memory.voice(message.author.id) is None:
+                self.memory.set_voice(message.author.id, sample.tolist())
+            best_user = None
+            best_dist = float("inf")
+            for uid, feat_list in self.memory.db["voices"].items():
+                dist = self.voice_recognizer.distance(sample, np.array(feat_list))
+                if dist < best_dist:
+                    best_dist = dist
+                    best_user = uid
+            if best_user is not None and best_user != message.author.id:
+                user = (
+                    message.guild.get_member(best_user) if message.guild else None
+                )
+                if user:
+                    await message.channel.send(f"That sounds like {user.mention}")
+
         # Only respond when mentioned or when this bot's name is in the text
         name_to_check = self.name.lower() if self.name else self.bot.user.name.lower()
         if not (
@@ -264,7 +292,7 @@ class ChatBot(commands.Cog):
     @commands.command()
     async def help(self, ctx: commands.Context):
         await ctx.send(
-            "Available commands: /ping, /help, /train, /deeptrain, /tictactoe, /move, /rps, /rpsmove, /guessnumber, /guess, /hangman, /hang, /adventure, /adv, /dm, /history, /clearhistory, /giftcookies, /cookies, /rewards, /converse, /join, /leave, /play, /transcribe, /registervoice, /identifyvoice"
+            "Available commands: /ping, /help, /train, /deeptrain, /tictactoe, /move, /rps, /rpsmove, /guessnumber, /guess, /hangman, /hang, /adventure, /adv, /dm, /history, /clearhistory, /giftcookies, /cookies, /rewards, /converse, /join, /leave, /play, /transcribe, /registervoice"
         )
 
     @commands.command()
@@ -580,37 +608,7 @@ class ChatBot(commands.Cog):
         self.memory.set_voice(ctx.author.id, feat.tolist())
         await ctx.send("Voice sample registered.")
 
-    @commands.command()
-    async def identifyvoice(self, ctx: commands.Context):
-        """Identify which registered user matches the attached audio."""
-        if not ctx.message.attachments:
-            await ctx.send("Attach an audio sample to identify.")
-            return
-        attachment = ctx.message.attachments[0]
-        with tempfile.NamedTemporaryFile(delete=False) as tmp:
-            await attachment.save(tmp.name)
-            path = tmp.name
-        sample = self.voice_recognizer.extract(path)
-        os.remove(path)
-        best_user = None
-        best_dist = float("inf")
-        for uid, feat_list in self.memory.db["voices"].items():
-            dist = self.voice_recognizer.distance(sample, np.array(feat_list))
-            if dist < best_dist:
-                best_dist = dist
-                best_user = uid
-        if best_user is not None:
-            user = ctx.guild.get_member(best_user)
-            if user:
-                await ctx.send(f"Sounds like {user.mention}")
-                try:
-                    await user.send("Your voice was recognized!")
-                except Exception:
-                    pass
-            else:
-                await ctx.send("User not found in this server.")
-        else:
-            await ctx.send("No matching voice registered.")
+
 
 
 async def run_single(token: str, sibling: str | None = None):

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -404,13 +404,16 @@ class ChatBot(commands.Cog):
     @commands.command()
     async def join(self, ctx: commands.Context):
         """Join the voice channel of the command author."""
-        if ctx.author.voice:
-            channel = ctx.author.voice.channel
-            vc = await channel.connect()
-            self.voice_clients[ctx.guild.id] = vc
-            await ctx.send(f"Joined {channel.name}")
-        else:
+        if not ctx.author.voice:
             await ctx.send("You are not in a voice channel.")
+            return
+        if ctx.guild.id in self.voice_clients:
+            await ctx.send("Already connected.")
+            return
+        channel = ctx.author.voice.channel
+        vc = await channel.connect()
+        self.voice_clients[ctx.guild.id] = vc
+        await ctx.send(f"Joined {channel.name}")
 
     @commands.command()
     async def leave(self, ctx: commands.Context):

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -106,6 +106,10 @@ class ChatBot(commands.Cog):
         self.stt = SpeechToText(lang=os.getenv("STT_LANG", "en-US"))
         self.voice_recognizer = VoiceRecognizer()
 
+        # Relationships
+        # Each user has a score from 1-100 per bot
+        # Start around neutral (50)
+
         # Logger and dialogue memory
         self.logger = Logger()
         self.dialogue = DialogueMemory()
@@ -236,6 +240,12 @@ class ChatBot(commands.Cog):
             return
 
         personality = self.sibling_personalities.get(self.name, self.personality)
+        # Strengthen relationship slightly whenever a user talks to the bot
+        self.memory.adjust_relationship(
+            message.author.id,
+            self.name or self.bot.user.name,
+            1,
+        )
 
         tokens = self.tokenizer.encode(message.content)
         prompt = self.tokenizer.decode(tokens)
@@ -292,7 +302,7 @@ class ChatBot(commands.Cog):
     @commands.command()
     async def help(self, ctx: commands.Context):
         await ctx.send(
-            "Available commands: /ping, /help, /train, /deeptrain, /tictactoe, /move, /rps, /rpsmove, /guessnumber, /guess, /hangman, /hang, /adventure, /adv, /dm, /history, /clearhistory, /giftcookies, /cookies, /rewards, /converse, /join, /leave, /play, /transcribe, /registervoice"
+            "Available commands: /ping, /help, /train, /deeptrain, /tictactoe, /move, /rps, /rpsmove, /guessnumber, /guess, /hangman, /hang, /adventure, /adv, /dm, /history, /clearhistory, /giftcookies, /cookies, /rewards, /relationship, /converse, /join, /leave, /play, /transcribe, /registervoice"
         )
 
     @commands.command()
@@ -505,6 +515,14 @@ class ChatBot(commands.Cog):
         await ctx.send(f"You have {points} reward points.")
 
     @commands.command()
+    async def relationship(self, ctx: commands.Context):
+        """Show your relationship score with this bot."""
+        score = self.memory.relationship(
+            ctx.author.id, self.name or self.bot.user.name
+        )
+        await ctx.send(f"Our relationship score is {score}/100")
+
+    @commands.command()
     async def converse(self, ctx: commands.Context, rounds: int = 4, *, start: str = "Hello"):
         """Make this bot chat with its sibling for a few rounds."""
         others = [s for s in self.siblings if s != self.name]
@@ -611,10 +629,10 @@ class ChatBot(commands.Cog):
 
 
 
-async def run_single(token: str, sibling: str | None = None):
+async def run_single(token: str, sibling: str | None = None, prefix: str = "/"):
     intents = discord.Intents.default()
     intents.message_content = True
-    bot = commands.Bot(command_prefix="/", intents=intents)
+    bot = commands.Bot(command_prefix=prefix, intents=intents)
     await bot.add_cog(ChatBot(bot, name=sibling))
 
     @bot.event
@@ -639,9 +657,11 @@ def main():
 
     async def runner():
         tasks = []
+        multiple = len(tokens) > 1
         for i, token in enumerate(tokens):
             sibling = sibling_names[i] if i < len(sibling_names) else None
-            tasks.append(run_single(token, sibling))
+            prefix = f"/{sibling.lower()} " if multiple and sibling else "/"
+            tasks.append(run_single(token, sibling, prefix))
         await asyncio.gather(*tasks)
 
     asyncio.run(runner())

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -4,6 +4,7 @@ import random
 import asyncio
 import tempfile
 import discord
+import numpy as np
 from discord.ext import commands
 
 from .tokenizer import SimpleTokenizer
@@ -16,6 +17,7 @@ from .adventure import AdventureGame
 from .dialogue import DialogueMemory
 from .logger import Logger
 from .utils import env_bool, env_list
+from .voice_recognizer import VoiceRecognizer
 
 # Keep track of running bot instances so they can converse
 BOT_REGISTRY: dict[str, commands.Bot] = {}
@@ -102,6 +104,7 @@ class ChatBot(commands.Cog):
         self.enable_tts = env_bool("ENABLE_TTS", True)
         self.tts = TextToSpeech(lang=os.getenv("TTS_LANG", "en"))
         self.stt = SpeechToText(lang=os.getenv("STT_LANG", "en-US"))
+        self.voice_recognizer = VoiceRecognizer()
 
         # Logger and dialogue memory
         self.logger = Logger()
@@ -261,7 +264,7 @@ class ChatBot(commands.Cog):
     @commands.command()
     async def help(self, ctx: commands.Context):
         await ctx.send(
-            "Available commands: /ping, /help, /train, /deeptrain, /tictactoe, /move, /rps, /rpsmove, /guessnumber, /guess, /hangman, /hang, /adventure, /adv, /dm, /history, /clearhistory, /giftcookies, /cookies, /rewards, /converse, /join, /leave, /play, /transcribe"
+            "Available commands: /ping, /help, /train, /deeptrain, /tictactoe, /move, /rps, /rpsmove, /guessnumber, /guess, /hangman, /hang, /adventure, /adv, /dm, /history, /clearhistory, /giftcookies, /cookies, /rewards, /converse, /join, /leave, /play, /transcribe, /registervoice, /identifyvoice"
         )
 
     @commands.command()
@@ -561,6 +564,53 @@ class ChatBot(commands.Cog):
             await ctx.send(f"Transcription: {text}")
         else:
             await ctx.send("Unable to transcribe the audio.")
+
+    @commands.command()
+    async def registervoice(self, ctx: commands.Context):
+        """Register your voice with an attached audio sample."""
+        if not ctx.message.attachments:
+            await ctx.send("Attach an audio sample to register.")
+            return
+        attachment = ctx.message.attachments[0]
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            await attachment.save(tmp.name)
+            path = tmp.name
+        feat = self.voice_recognizer.extract(path)
+        os.remove(path)
+        self.memory.set_voice(ctx.author.id, feat.tolist())
+        await ctx.send("Voice sample registered.")
+
+    @commands.command()
+    async def identifyvoice(self, ctx: commands.Context):
+        """Identify which registered user matches the attached audio."""
+        if not ctx.message.attachments:
+            await ctx.send("Attach an audio sample to identify.")
+            return
+        attachment = ctx.message.attachments[0]
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            await attachment.save(tmp.name)
+            path = tmp.name
+        sample = self.voice_recognizer.extract(path)
+        os.remove(path)
+        best_user = None
+        best_dist = float("inf")
+        for uid, feat_list in self.memory.db["voices"].items():
+            dist = self.voice_recognizer.distance(sample, np.array(feat_list))
+            if dist < best_dist:
+                best_dist = dist
+                best_user = uid
+        if best_user is not None:
+            user = ctx.guild.get_member(best_user)
+            if user:
+                await ctx.send(f"Sounds like {user.mention}")
+                try:
+                    await user.send("Your voice was recognized!")
+                except Exception:
+                    pass
+            else:
+                await ctx.send("User not found in this server.")
+        else:
+            await ctx.send("No matching voice registered.")
 
 
 async def run_single(token: str, sibling: str | None = None):

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -24,8 +24,9 @@ async def call_ai_model(prompt: str) -> str:
     return f"Echo: {prompt}"
 
 class ChatBot(commands.Cog):
-    def __init__(self, bot: commands.Bot, tokenizer=None):
+    def __init__(self, bot: commands.Bot, tokenizer=None, name: str | None = None):
         self.bot = bot
+        self.name = name
         self.tokenizer = tokenizer or SimpleTokenizer()
         self.personality = os.getenv(
             "BOT_PERSONALITY",
@@ -34,9 +35,9 @@ class ChatBot(commands.Cog):
 
         self.siblings = env_list("BOT_SIBLINGS", "Alpha,Beta")
         self.sibling_personalities = {}
-        for name in self.siblings:
-            key = f"BOT_PERSONALITY_{name.upper()}"
-            self.sibling_personalities[name] = os.getenv(key, self.personality)
+        for s in self.siblings:
+            key = f"BOT_PERSONALITY_{s.upper()}"
+            self.sibling_personalities[s] = os.getenv(key, self.personality)
 
         self.last_messages = {}
 
@@ -121,19 +122,15 @@ class ChatBot(commands.Cog):
         if message.author != self.bot.user:
             self.last_messages[channel_id] = (message.author.id, message.content)
 
-        # Only respond when mentioned or when the bot name is in the text
+        # Only respond when mentioned or when this bot's name is in the text
+        name_to_check = self.name.lower() if self.name else self.bot.user.name.lower()
         if not (
             self.bot.user in message.mentions
-            or any(name.lower() in message.content.lower() for name in self.siblings)
+            or name_to_check in message.content.lower()
         ):
             return
 
-        # Determine which sibling should reply
-        sibling = next(
-            (name for name in self.siblings if name.lower() in message.content.lower()),
-            self.siblings[0],
-        )
-        personality = self.sibling_personalities.get(sibling, self.personality)
+        personality = self.sibling_personalities.get(self.name, self.personality)
 
         tokens = self.tokenizer.encode(message.content)
         prompt = self.tokenizer.decode(tokens)
@@ -416,16 +413,34 @@ class ChatBot(commands.Cog):
         await ctx.send(f"Playing {file_path}.")
 
 
-def main():
+async def run_single(token: str, sibling: str | None = None):
     intents = discord.Intents.default()
     intents.message_content = True
     bot = commands.Bot(command_prefix="/", intents=intents)
-    bot.add_cog(ChatBot(bot))
+    bot.add_cog(ChatBot(bot, name=sibling))
+    await bot.start(token)
 
-    token = os.getenv("DISCORD_TOKEN")
-    if not token:
-        raise RuntimeError("DISCORD_TOKEN environment variable not set")
-    bot.run(token)
+
+def main():
+    tokens_env = os.getenv("DISCORD_TOKENS")
+    if tokens_env:
+        tokens = [t.strip() for t in tokens_env.split(",") if t.strip()]
+    else:
+        token = os.getenv("DISCORD_TOKEN")
+        if not token:
+            raise RuntimeError("DISCORD_TOKEN or DISCORD_TOKENS must be set")
+        tokens = [token]
+
+    sibling_names = env_list("BOT_SIBLINGS", "Alpha,Beta")
+
+    async def runner():
+        tasks = []
+        for i, token in enumerate(tokens):
+            sibling = sibling_names[i] if i < len(sibling_names) else None
+            tasks.append(run_single(token, sibling))
+        await asyncio.gather(*tasks)
+
+    asyncio.run(runner())
 
 if __name__ == "__main__":
     main()

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -1,0 +1,431 @@
+import os
+import ast
+import random
+import discord
+from discord.ext import commands
+
+from .tokenizer import SimpleTokenizer
+from .memory import Memory
+from .games import TicTacToeGame, RockPaperScissorsGame, GuessNumberGame, HangmanGame
+from .tts import TextToSpeech
+from .game_ai import GameAI
+from .adventure import AdventureGame
+from .dialogue import DialogueMemory
+from .logger import Logger
+from .utils import env_bool, env_list
+
+# Choose your AI backend here. Replace with your own implementation.
+# For demonstration, we use a placeholder function.
+
+async def call_ai_model(prompt: str) -> str:
+    """Placeholder AI call. Replace with your own model integration."""
+    # In a real implementation, send `prompt` to your model (OpenAI, Llama, etc.)
+    # and return the model's response.
+    return f"Echo: {prompt}"
+
+class ChatBot(commands.Cog):
+    def __init__(self, bot: commands.Bot, tokenizer=None):
+        self.bot = bot
+        self.tokenizer = tokenizer or SimpleTokenizer()
+        self.personality = os.getenv(
+            "BOT_PERSONALITY",
+            "You are an entertaining and helpful assistant who may use mild swearing but never slurs."
+        )
+
+        self.siblings = env_list("BOT_SIBLINGS", "Alpha,Beta")
+        self.sibling_personalities = {}
+        for name in self.siblings:
+            key = f"BOT_PERSONALITY_{name.upper()}"
+            self.sibling_personalities[name] = os.getenv(key, self.personality)
+
+        self.last_messages = {}
+
+        # Persistent memory handler
+        self.memory = Memory()
+
+        # Active games per channel
+        self.tictactoe_games = {}
+        self.rps_games = {}
+        self.guess_games = {}
+        self.hangman_games = {}
+        self.adventure_games = {}
+        self.voice_clients = {}
+
+        # Voice and TTS
+        self.enable_tts = env_bool("ENABLE_TTS", True)
+        self.tts = TextToSpeech(lang=os.getenv("TTS_LANG", "en"))
+
+        # Logger and dialogue memory
+        self.logger = Logger()
+        self.dialogue = DialogueMemory()
+
+        # Game AI stub
+        self.game_ai = GameAI()
+
+        # Cursing and slur filter configuration
+        self.allowed_cuss = {"damn", "shit", "fuck"}
+        # Replace with your own blocked terms; these are placeholders
+        self.blocked_words = {"badslur1", "badslur2"}
+
+    def cog_unload(self):
+        self.memory.close()
+        self.logger.log("Cog unloaded")
+
+    # Utility methods
+    def history(self, channel_id: int) -> str:
+        return self.memory.history(channel_id)
+
+    def update_history(self, channel_id: int, entry: str) -> None:
+        self.memory.update_history(channel_id, entry)
+
+    def filter_output(self, text: str) -> str:
+        """Replace blocked words with [filtered] while allowing mild cussing."""
+        tokens = text.split()
+        out_tokens = []
+        for t in tokens:
+            word = t.lower().strip(".,!?")
+            if word in self.blocked_words:
+                out_tokens.append("[filtered]")
+            else:
+                out_tokens.append(t)
+        return " ".join(out_tokens)
+
+    def think(self, message: str) -> str | None:
+        """Very small reasoning step for math expressions."""
+        try:
+            tree = ast.parse(message, mode="eval")
+            if all(isinstance(node, (ast.Expression, ast.BinOp, ast.UnaryOp, ast.Num, ast.operator)) for node in ast.walk(tree)):
+                result = eval(compile(tree, filename="<ast>", mode="eval"))
+                return str(result)
+        except Exception:
+            pass
+        return None
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message):
+        if message.author == self.bot.user:
+            return
+        self.logger.log(f"Message from {message.author}: {message.content}")
+        self.dialogue.add(message.author.id, "User", message.content)
+
+        ctx = await self.bot.get_context(message)
+        if ctx.valid:
+            return  # Let command processing handle it
+
+        channel_id = message.channel.id
+
+        # Learn from human-to-human conversations
+        last = self.last_messages.get(channel_id)
+        if last and last[0] != message.author.id:
+            self.memory.add_training(last[1], message.content)
+        if message.author != self.bot.user:
+            self.last_messages[channel_id] = (message.author.id, message.content)
+
+        # Only respond when mentioned or when the bot name is in the text
+        if not (
+            self.bot.user in message.mentions
+            or any(name.lower() in message.content.lower() for name in self.siblings)
+        ):
+            return
+
+        # Determine which sibling should reply
+        sibling = next(
+            (name for name in self.siblings if name.lower() in message.content.lower()),
+            self.siblings[0],
+        )
+        personality = self.sibling_personalities.get(sibling, self.personality)
+
+        tokens = self.tokenizer.encode(message.content)
+        prompt = self.tokenizer.decode(tokens)
+
+        # Simple reasoning step (math evaluation)
+        thought = self.think(prompt)
+        if thought is not None:
+            await message.channel.send(thought)
+            self.update_history(channel_id, f"\nUser: {prompt}\nAssistant: {thought}")
+            return
+
+        history = self.history(channel_id)
+        training = self.memory.training()
+        if prompt in training:
+            response = training[prompt]
+        else:
+            combined_prompt = f"{personality}\n{history}\nUser: {prompt}\nAssistant:"
+            response = await call_ai_model(combined_prompt)
+
+        filtered = self.filter_output(response)
+        self.memory.add_training(prompt, response)
+        await message.channel.send(filtered)
+        # Send a private message to the user as well
+        if self.enable_tts:
+            try:
+                await message.author.send(filtered)
+            except Exception:
+                pass
+        self.update_history(channel_id, f"\nUser: {prompt}\nAssistant: {filtered}")
+        self.logger.log(f"Response: {filtered}")
+        self.dialogue.add(message.author.id, "Assistant", filtered)
+
+    def reward(self, user_id: int, amount: int = 1):
+        """Reward a user with points."""
+        self.memory.add_reward(user_id, amount)
+
+    @commands.command()
+    async def ping(self, ctx: commands.Context):
+        await ctx.send("Pong!")
+
+    @commands.command()
+    async def help(self, ctx: commands.Context):
+        await ctx.send(
+            "Available commands: /ping, /help, /train, /tictactoe, /move, /rps, /rpsmove, /guessnumber, /guess, /hangman, /hang, /adventure, /adv, /dm, /history, /clearhistory, /giftcookies, /cookies, /rewards, /join, /leave, /play"
+        )
+
+    @commands.command()
+    async def train(self, ctx: commands.Context, prompt: str, response: str):
+        """Store a simple training pair."""
+        self.memory.add_training(prompt, response)
+        await ctx.send("Training example stored.")
+
+    @commands.command()
+    async def tictactoe(self, ctx: commands.Context, opponent: discord.Member):
+        channel = ctx.channel.id
+        if channel in self.tictactoe_games:
+            await ctx.send("A game is already in progress in this channel.")
+            return
+        self.tictactoe_games[channel] = TicTacToeGame(ctx.author.id, opponent.id)
+        await ctx.send(
+            f"TicTacToe started! {ctx.author.mention} vs {opponent.mention}. Use /move <0-8>."
+        )
+
+    @commands.command()
+    async def move(self, ctx: commands.Context, position: int):
+        channel = ctx.channel.id
+        game = self.tictactoe_games.get(channel)
+        if not game:
+            await ctx.send("No active game in this channel.")
+            return
+        msg, result = game.make_move(ctx.author.id, position)
+        if msg:
+            await ctx.send(msg)
+        if result == "END":
+            winner_mark = game.check_winner()
+            if winner_mark:
+                winner_id = (
+                    game.state.players[0] if winner_mark == "X" else game.state.players[1]
+                )
+                self.reward(winner_id)
+            del self.tictactoe_games[channel]
+
+    @commands.command()
+    async def history(self, ctx: commands.Context, limit: int = 10):
+        channel = ctx.channel.id
+        hist = self.history(channel)
+        entries = hist.strip().split("\n")[-2 * limit:]
+        if entries:
+            await ctx.send("\n".join(entries))
+        else:
+            await ctx.send("No history.")
+
+    @commands.command()
+    async def clearhistory(self, ctx: commands.Context):
+        channel = ctx.channel.id
+        self.memory.clear_history(channel)
+        await ctx.send("History cleared.")
+
+    @commands.command()
+    async def rps(self, ctx: commands.Context, opponent: discord.Member, rounds: int = 3):
+        channel = ctx.channel.id
+        if channel in self.rps_games:
+            await ctx.send("Rock Paper Scissors already running in this channel.")
+            return
+        self.rps_games[channel] = RockPaperScissorsGame(ctx.author.id, opponent.id, rounds)
+        await ctx.send(
+            f"RPS started! {ctx.author.mention} vs {opponent.mention}. Use /rpsmove <choice>."
+        )
+
+    @commands.command()
+    async def rpsmove(self, ctx: commands.Context, choice: str):
+        channel = ctx.channel.id
+        game = self.rps_games.get(channel)
+        if not game:
+            await ctx.send("No active RPS game in this channel.")
+            return
+        if ctx.author.id == game.players[0]:
+            game_choice = choice
+            bot_choice = random.choice(RockPaperScissorsGame.CHOICES)
+            result = game.play_round(game_choice, bot_choice)
+            await ctx.send(f"You chose {game_choice}, bot chose {bot_choice}. {result}")
+        else:
+            await ctx.send("Only the game starter can play against the bot.")
+        if game.state.current_round >= game.state.rounds:
+            p1 = game.players[0]
+            p2 = game.players[1]
+            s1 = game.state.scores[p1]
+            s2 = game.state.scores[p2]
+            if s1 > s2:
+                self.reward(p1)
+            elif s2 > s1:
+                self.reward(p2)
+            del self.rps_games[channel]
+
+    @commands.command()
+    async def guessnumber(self, ctx: commands.Context, max_attempts: int = 5):
+        """Start a number guessing game."""
+        channel = ctx.channel.id
+        if channel in self.guess_games:
+            await ctx.send("GuessNumber already running in this channel.")
+            return
+        self.guess_games[channel] = GuessNumberGame(max_attempts)
+        await ctx.send("Guess a number between 1 and 100 using /guess <num>.")
+
+    @commands.command()
+    async def guess(self, ctx: commands.Context, number: int):
+        channel = ctx.channel.id
+        game = self.guess_games.get(channel)
+        if not game:
+            await ctx.send("No active GuessNumber game.")
+            return
+        result = game.guess(number)
+        await ctx.send(result)
+        if "Correct" in result:
+            self.reward(ctx.author.id)
+        if "Correct" in result or "Out of attempts" in result:
+            del self.guess_games[channel]
+
+    @commands.command()
+    async def dm(self, ctx: commands.Context, *, message: str):
+        """Send yourself a private message from the bot."""
+        try:
+            await ctx.author.send(message)
+            await ctx.send("DM sent.")
+        except Exception:
+            await ctx.send("Unable to send DM.")
+
+    @commands.command()
+    async def hangman(self, ctx: commands.Context, max_attempts: int = 6):
+        """Start a hangman game."""
+        channel = ctx.channel.id
+        if channel in self.hangman_games:
+            await ctx.send("Hangman already running in this channel.")
+            return
+        self.hangman_games[channel] = HangmanGame(max_attempts)
+        game = self.hangman_games[channel]
+        await ctx.send(f"Hangman started! {game.state.display()} Use /hang <letter>.")
+
+    @commands.command()
+    async def hang(self, ctx: commands.Context, letter: str):
+        channel = ctx.channel.id
+        game = self.hangman_games.get(channel)
+        if not game:
+            await ctx.send("No active Hangman game.")
+            return
+        result = game.guess(letter)
+        await ctx.send(result)
+        if "You win" in result:
+            self.reward(ctx.author.id)
+        if "Game over" in result or "You win" in result:
+            del self.hangman_games[channel]
+
+    @commands.command()
+    async def adventure(self, ctx: commands.Context):
+        """Start a tiny text adventure."""
+        channel = ctx.channel.id
+        if channel in self.adventure_games:
+            await ctx.send("Adventure already running. Use /adv to play.")
+            return
+        self.adventure_games[channel] = AdventureGame()
+        await ctx.send(self.adventure_games[channel].look())
+
+    @commands.command()
+    async def adv(self, ctx: commands.Context, *, command: str):
+        game = self.adventure_games.get(ctx.channel.id)
+        if not game:
+            await ctx.send("No active adventure. Start with /adventure.")
+            return
+        result = game.handle_command(command)
+        await ctx.send(result)
+        if game.game_over:
+            del self.adventure_games[ctx.channel.id]
+
+    # Cookie and reward commands
+    @commands.command()
+    async def giftcookies(self, ctx: commands.Context, amount: int = 1):
+        """Give the bot happiness cookies (server owner only)."""
+        if not ctx.guild:
+            await ctx.send("This command must be used in a server.")
+            return
+        if ctx.author.id != ctx.guild.owner_id:
+            await ctx.send("Only the server owner can gift cookies.")
+            return
+        self.memory.add_cookies(ctx.guild.id, amount)
+        total = self.memory.cookies(ctx.guild.id)
+        await ctx.send(f"Yum! Thank you for {amount} cookies. Total: {total}")
+
+    @commands.command()
+    async def cookies(self, ctx: commands.Context):
+        """Check how many cookies the bot has."""
+        if not ctx.guild:
+            await ctx.send("Use this in a server.")
+            return
+        total = self.memory.cookies(ctx.guild.id)
+        await ctx.send(f"I currently have {total} cookies!")
+
+    @commands.command()
+    async def rewards(self, ctx: commands.Context):
+        """Show your reward points."""
+        points = self.memory.rewards(ctx.author.id)
+        await ctx.send(f"You have {points} reward points.")
+
+    # Voice channel commands
+    @commands.command()
+    async def join(self, ctx: commands.Context):
+        """Join the voice channel of the command author."""
+        if ctx.author.voice:
+            channel = ctx.author.voice.channel
+            vc = await channel.connect()
+            self.voice_clients[ctx.guild.id] = vc
+            await ctx.send(f"Joined {channel.name}")
+        else:
+            await ctx.send("You are not in a voice channel.")
+
+    @commands.command()
+    async def leave(self, ctx: commands.Context):
+        """Disconnect from the current voice channel."""
+        vc = self.voice_clients.get(ctx.guild.id)
+        if vc:
+            await vc.disconnect()
+            del self.voice_clients[ctx.guild.id]
+            await ctx.send("Left the voice channel.")
+        else:
+            await ctx.send("Not connected to a voice channel.")
+
+    @commands.command()
+    async def play(self, ctx: commands.Context, file_path: str):
+        """Play a local audio file in the current voice channel."""
+        vc = self.voice_clients.get(ctx.guild.id)
+        if not vc:
+            await ctx.send("Join a voice channel first with /join.")
+            return
+        if not os.path.isfile(file_path):
+            await ctx.send("Audio file not found.")
+            return
+        if vc.is_playing():
+            vc.stop()
+        source = discord.FFmpegPCMAudio(file_path)
+        vc.play(source)
+        await ctx.send(f"Playing {file_path}.")
+
+
+def main():
+    intents = discord.Intents.default()
+    intents.message_content = True
+    bot = commands.Bot(command_prefix="/", intents=intents)
+    bot.add_cog(ChatBot(bot))
+
+    token = os.getenv("DISCORD_TOKEN")
+    if not token:
+        raise RuntimeError("DISCORD_TOKEN environment variable not set")
+    bot.run(token)
+
+if __name__ == "__main__":
+    main()

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -19,6 +19,7 @@ from .utils import env_bool, env_list
 
 # Keep track of running bot instances so they can converse
 BOT_REGISTRY: dict[str, commands.Bot] = {}
+BOT_USERS: dict[int, str] = {}
 import pickle
 from .markov import MarkovChain
 from .lstm_model import LSTMModel
@@ -30,6 +31,9 @@ LSTM_MODEL_PATH = os.getenv("LSTM_MODEL_PATH", "lstm_model.h5")
 LSTM_VOCAB_PATH = os.getenv("LSTM_VOCAB_PATH", "lstm_vocab.pkl")
 _chain: MarkovChain | None = None
 _lstm: LSTMModel | None = None
+
+# Limit automatic sibling conversation to avoid infinite loops
+MAX_CONVERSE_ROUNDS = 6
 
 
 async def call_ai_model(prompt: str) -> str:
@@ -91,6 +95,8 @@ class ChatBot(commands.Cog):
         self.hangman_games = {}
         self.adventure_games = {}
         self.voice_clients = {}
+        # Track ongoing sibling conversations per channel
+        self.converse_depth: dict[int, int] = {}
 
         # Voice and TTS
         self.enable_tts = env_bool("ENABLE_TTS", True)
@@ -160,14 +166,27 @@ class ChatBot(commands.Cog):
     async def on_message(self, message: discord.Message):
         if message.author == self.bot.user:
             return
+
+        channel_id = message.channel.id
+
+        # Track human vs bot messages to manage sibling conversations
+        if not message.author.bot:
+            self.converse_depth[channel_id] = 0
+        elif message.author.name in self.siblings and message.author.name != self.name:
+            depth = self.converse_depth.get(channel_id, 0)
+            if depth >= MAX_CONVERSE_ROUNDS:
+                return
+            self.converse_depth[channel_id] = depth + 1
+            respond_anyway = True
+        else:
+            respond_anyway = False
+
         self.logger.log(f"Message from {message.author}: {message.content}")
         self.dialogue.add(message.author.id, "User", message.content)
 
         ctx = await self.bot.get_context(message)
         if ctx.valid:
             return  # Let command processing handle it
-
-        channel_id = message.channel.id
 
         # Learn from human-to-human conversations
         last = self.last_messages.get(channel_id)
@@ -181,6 +200,7 @@ class ChatBot(commands.Cog):
         if not (
             self.bot.user in message.mentions
             or name_to_check in message.content.lower()
+            or respond_anyway
         ):
             return
 
@@ -552,6 +572,7 @@ async def run_single(token: str, sibling: str | None = None):
     @bot.event
     async def on_ready():
         BOT_REGISTRY[sibling or bot.user.name] = bot
+        BOT_USERS[bot.user.id] = sibling or bot.user.name
 
     await bot.start(token)
 

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -16,6 +16,9 @@ from .adventure import AdventureGame
 from .dialogue import DialogueMemory
 from .logger import Logger
 from .utils import env_bool, env_list
+
+# Keep track of running bot instances so they can converse
+BOT_REGISTRY: dict[str, commands.Bot] = {}
 import pickle
 from .markov import MarkovChain
 from .lstm_model import LSTMModel
@@ -238,7 +241,7 @@ class ChatBot(commands.Cog):
     @commands.command()
     async def help(self, ctx: commands.Context):
         await ctx.send(
-            "Available commands: /ping, /help, /train, /deeptrain, /tictactoe, /move, /rps, /rpsmove, /guessnumber, /guess, /hangman, /hang, /adventure, /adv, /dm, /history, /clearhistory, /giftcookies, /cookies, /rewards, /join, /leave, /play, /transcribe"
+            "Available commands: /ping, /help, /train, /deeptrain, /tictactoe, /move, /rps, /rpsmove, /guessnumber, /guess, /hangman, /hang, /adventure, /adv, /dm, /history, /clearhistory, /giftcookies, /cookies, /rewards, /converse, /join, /leave, /play, /transcribe"
         )
 
     @commands.command()
@@ -450,6 +453,36 @@ class ChatBot(commands.Cog):
         points = self.memory.rewards(ctx.author.id)
         await ctx.send(f"You have {points} reward points.")
 
+    @commands.command()
+    async def converse(self, ctx: commands.Context, rounds: int = 4, *, start: str = "Hello"):
+        """Make this bot chat with its sibling for a few rounds."""
+        others = [s for s in self.siblings if s != self.name]
+        if not others:
+            await ctx.send("No sibling configured to talk to.")
+            return
+        other = others[0]
+        other_bot = BOT_REGISTRY.get(other)
+        if not other_bot:
+            await ctx.send(f"Sibling {other} is not online.")
+            return
+        channel = ctx.channel
+        history = ""
+        last = start
+        for i in range(rounds):
+            prompt_self = f"{self.sibling_personalities.get(self.name, self.personality)}\n{history}\nUser: {last}\nAssistant:"
+            resp_self = await call_ai_model(prompt_self)
+            resp_self = self.filter_output(resp_self)
+            await channel.send(resp_self)
+            history += f"\n{self.name}: {resp_self}"
+            last = resp_self
+
+            prompt_other = f"{self.sibling_personalities.get(other, self.personality)}\n{history}\nUser: {last}\nAssistant:"
+            resp_other = await call_ai_model(prompt_other)
+            resp_other = self.filter_output(resp_other)
+            await other_bot.get_channel(channel.id).send(resp_other)
+            history += f"\n{other}: {resp_other}"
+            last = resp_other
+
     # Voice channel commands
     @commands.command()
     async def join(self, ctx: commands.Context):
@@ -515,6 +548,11 @@ async def run_single(token: str, sibling: str | None = None):
     intents.message_content = True
     bot = commands.Bot(command_prefix="/", intents=intents)
     bot.add_cog(ChatBot(bot, name=sibling))
+
+    @bot.event
+    async def on_ready():
+        BOT_REGISTRY[sibling or bot.user.name] = bot
+
     await bot.start(token)
 
 

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -615,7 +615,7 @@ async def run_single(token: str, sibling: str | None = None):
     intents = discord.Intents.default()
     intents.message_content = True
     bot = commands.Bot(command_prefix="/", intents=intents)
-    bot.add_cog(ChatBot(bot, name=sibling))
+    await bot.add_cog(ChatBot(bot, name=sibling))
 
     @bot.event
     async def on_ready():

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -70,7 +70,7 @@ class ChatBot(commands.Cog):
             "You are an entertaining and helpful assistant who may use mild swearing but never slurs."
         )
 
-        self.siblings = env_list("BOT_SIBLINGS", "Vivi,Beta")
+        self.siblings = env_list("BOT_SIBLINGS", "Vivi,Vex")
         self.sibling_personalities = {}
         for s in self.siblings:
             key = f"BOT_PERSONALITY_{s.upper()}"
@@ -528,7 +528,7 @@ def main():
             raise RuntimeError("DISCORD_TOKEN or DISCORD_TOKENS must be set")
         tokens = [token]
 
-    sibling_names = env_list("BOT_SIBLINGS", "Vivi,Beta")
+    sibling_names = env_list("BOT_SIBLINGS", "Vivi,Vex")
 
     async def runner():
         tasks = []

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -14,14 +14,30 @@ from .adventure import AdventureGame
 from .dialogue import DialogueMemory
 from .logger import Logger
 from .utils import env_bool, env_list
+from .markov import MarkovChain
 
-# Choose your AI backend here. Replace with your own implementation.
-# For demonstration, we use a placeholder function.
+# Choose your AI backend here. By default we use a tiny Markov chain model.
+
+MODEL_PATH = os.getenv("MODEL_PATH", "markov_model.pkl")
+_chain: MarkovChain | None = None
+
 
 async def call_ai_model(prompt: str) -> str:
-    """Placeholder AI call. Replace with your own model integration."""
-    # In a real implementation, send `prompt` to your model (OpenAI, Llama, etc.)
-    # and return the model's response.
+    """Generate a reply using a local Markov chain model."""
+    global _chain
+    if _chain is None:
+        tokenizer = SimpleTokenizer()
+        chain = MarkovChain(tokenizer)
+        if os.path.isfile(MODEL_PATH):
+            try:
+                chain.load(MODEL_PATH)
+                _chain = chain
+            except Exception:
+                _chain = None
+        else:
+            _chain = None
+    if _chain:
+        return _chain.generate(prompt)
     return f"Echo: {prompt}"
 
 class ChatBot(commands.Cog):

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -14,17 +14,35 @@ from .adventure import AdventureGame
 from .dialogue import DialogueMemory
 from .logger import Logger
 from .utils import env_bool, env_list
+import pickle
 from .markov import MarkovChain
+from .lstm_model import LSTMModel
 
 # Choose your AI backend here. By default we use a tiny Markov chain model.
 
 MODEL_PATH = os.getenv("MODEL_PATH", "markov_model.pkl")
+LSTM_MODEL_PATH = os.getenv("LSTM_MODEL_PATH", "lstm_model.h5")
+LSTM_VOCAB_PATH = os.getenv("LSTM_VOCAB_PATH", "lstm_vocab.pkl")
 _chain: MarkovChain | None = None
+_lstm: LSTMModel | None = None
 
 
 async def call_ai_model(prompt: str) -> str:
-    """Generate a reply using a local Markov chain model."""
-    global _chain
+    """Generate a reply using a local language model."""
+    global _chain, _lstm
+    # Prefer LSTM model if available
+    if _lstm is None:
+        if os.path.isfile(LSTM_MODEL_PATH) and os.path.isfile(LSTM_VOCAB_PATH):
+            try:
+                with open(LSTM_VOCAB_PATH, "rb") as f:
+                    stoi, itos = pickle.load(f)
+                _lstm = LSTMModel(LSTM_MODEL_PATH, stoi, itos)
+            except Exception:
+                _lstm = None
+    if _lstm:
+        return _lstm.generate(prompt)
+
+    # Fall back to Markov chain
     if _chain is None:
         tokenizer = SimpleTokenizer()
         chain = MarkovChain(tokenizer)

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -238,7 +238,7 @@ class ChatBot(commands.Cog):
     @commands.command()
     async def help(self, ctx: commands.Context):
         await ctx.send(
-            "Available commands: /ping, /help, /train, /tictactoe, /move, /rps, /rpsmove, /guessnumber, /guess, /hangman, /hang, /adventure, /adv, /dm, /history, /clearhistory, /giftcookies, /cookies, /rewards, /join, /leave, /play, /transcribe"
+            "Available commands: /ping, /help, /train, /deeptrain, /tictactoe, /move, /rps, /rpsmove, /guessnumber, /guess, /hangman, /hang, /adventure, /adv, /dm, /history, /clearhistory, /giftcookies, /cookies, /rewards, /join, /leave, /play, /transcribe"
         )
 
     @commands.command()
@@ -246,6 +246,19 @@ class ChatBot(commands.Cog):
         """Store a simple training pair."""
         self.memory.add_training(prompt, response)
         await ctx.send("Training example stored.")
+
+    @commands.command()
+    async def deeptrain(self, ctx: commands.Context):
+        """Run deep LSTM training using stored conversations."""
+        await ctx.send("Starting deep training. This may take a while...")
+        loop = asyncio.get_event_loop()
+
+        def _run():
+            from .train_lstm import main as train_main
+            train_main()
+
+        await loop.run_in_executor(None, _run)
+        await ctx.send("Deep training complete. New model saved.")
 
     @commands.command()
     async def tictactoe(self, ctx: commands.Context, opponent: discord.Member):

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -1,6 +1,7 @@
 import os
 import ast
 import random
+import asyncio
 import discord
 from discord.ext import commands
 
@@ -95,7 +96,20 @@ class ChatBot(commands.Cog):
         """Very small reasoning step for math expressions."""
         try:
             tree = ast.parse(message, mode="eval")
-            if all(isinstance(node, (ast.Expression, ast.BinOp, ast.UnaryOp, ast.Num, ast.operator)) for node in ast.walk(tree)):
+            if all(
+                isinstance(
+                    node,
+                    (
+                        ast.Expression,
+                        ast.BinOp,
+                        ast.UnaryOp,
+                        ast.Num,
+                        ast.Constant,
+                        ast.operator,
+                    ),
+                )
+                for node in ast.walk(tree)
+            ):
                 result = eval(compile(tree, filename="<ast>", mode="eval"))
                 return str(result)
         except Exception:
@@ -153,8 +167,21 @@ class ChatBot(commands.Cog):
         filtered = self.filter_output(response)
         self.memory.add_training(prompt, response)
         await message.channel.send(filtered)
-        # Send a private message to the user as well
         if self.enable_tts:
+            # If connected to a voice channel, speak the reply aloud
+            if message.guild and message.guild.id in self.voice_clients:
+                vc = self.voice_clients[message.guild.id]
+                try:
+                    path = self.tts.speak(filtered)
+                    if vc.is_playing():
+                        vc.stop()
+                    vc.play(
+                        discord.FFmpegPCMAudio(path),
+                        after=lambda e: os.remove(path),
+                    )
+                except Exception:
+                    pass
+            # Also send the text as a private message
             try:
                 await message.author.send(filtered)
             except Exception:

--- a/bot/dialogue.py
+++ b/bot/dialogue.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass, field
+
+@dataclass
+class DialogueEntry:
+    speaker: str
+    message: str
+
+@dataclass
+class DialogueMemory:
+    """Store conversation by user."""
+
+    history: dict[int, list[DialogueEntry]] = field(default_factory=dict)
+
+    def add(self, user_id: int, speaker: str, message: str) -> None:
+        self.history.setdefault(user_id, []).append(DialogueEntry(speaker, message))
+
+    def last(self, user_id: int, limit: int = 5) -> str:
+        entries = self.history.get(user_id, [])[-limit:]
+        return "\n".join(f"{e.speaker}: {e.message}" for e in entries)
+
+    def clear(self, user_id: int) -> None:
+        self.history[user_id] = []
+
+    def summarize(self, user_id: int) -> str:
+        """Placeholder summarization of conversation history."""
+        entries = self.history.get(user_id, [])
+        if not entries:
+            return ""
+        return f"Conversation with {len(entries)} messages."
+

--- a/bot/game_ai.py
+++ b/bot/game_ai.py
@@ -1,0 +1,13 @@
+class GameAI:
+    """Placeholder for an AI controlling in-game actions."""
+
+    def __init__(self):
+        # In a real implementation this could load a model or connect to
+        # a separate process that handles complex game logic.
+        self.state = {}
+
+    async def decide_action(self, game_state) -> str:
+        """Return a basic action given the current game state."""
+        # This is only a stub demonstrating where you'd put game logic.
+        return "move_forward"
+

--- a/bot/games.py
+++ b/bot/games.py
@@ -1,0 +1,159 @@
+import random
+from dataclasses import dataclass
+
+@dataclass
+class TicTacToeState:
+    board: list[str]
+    players: list[int]
+    turn: int = 0
+
+    def display(self) -> str:
+        return (
+            "|".join(self.board[0:3])
+            + "\n"
+            + "|".join(self.board[3:6])
+            + "\n"
+            + "|".join(self.board[6:9])
+        )
+
+class TicTacToeGame:
+    def __init__(self, player1: int, player2: int):
+        self.state = TicTacToeState(board=[" "] * 9, players=[player1, player2])
+
+    def make_move(self, player_id: int, position: int) -> tuple[str | None, str | None]:
+        if self.state.players[self.state.turn] != player_id:
+            return None, "It's not your turn."
+        if not 0 <= position <= 8 or self.state.board[position] != " ":
+            return None, "Invalid move."
+        mark = "X" if self.state.turn == 0 else "O"
+        self.state.board[position] = mark
+        self.state.turn = 1 - self.state.turn
+        winner = self.check_winner()
+        board_display = self.state.display()
+        if winner:
+            return f"```\n{board_display}\n```\n{winner} wins!", "END"
+        if " " not in self.state.board:
+            return f"```\n{board_display}\n```\nIt's a draw!", "END"
+        return f"```\n{board_display}\n```", None
+
+    def check_winner(self) -> str | None:
+        b = self.state.board
+        wins = [
+            (0, 1, 2),
+            (3, 4, 5),
+            (6, 7, 8),
+            (0, 3, 6),
+            (1, 4, 7),
+            (2, 5, 8),
+            (0, 4, 8),
+            (2, 4, 6),
+        ]
+        for a, b1, c in wins:
+            if b[a] == b[b1] == b[c] != " ":
+                return b[a]
+        return None
+
+@dataclass
+class RPSState:
+    scores: dict[int, int]
+    rounds: int
+    current_round: int = 0
+
+class RockPaperScissorsGame:
+    CHOICES = ["rock", "paper", "scissors"]
+
+    def __init__(self, player1: int, player2: int, rounds: int = 3):
+        self.state = RPSState(scores={player1: 0, player2: 0}, rounds=rounds)
+        self.players = [player1, player2]
+
+    def play_round(self, p1_choice: str, p2_choice: str) -> str:
+        p1_choice = p1_choice.lower()
+        p2_choice = p2_choice.lower()
+        if p1_choice not in self.CHOICES or p2_choice not in self.CHOICES:
+            return "Invalid choice. Use rock, paper, or scissors."
+        result = self.determine_winner(p1_choice, p2_choice)
+        self.state.current_round += 1
+        if result == 0:
+            outcome = "Tie!"
+        elif result == 1:
+            self.state.scores[self.players[0]] += 1
+            outcome = "Player 1 wins the round!"
+        else:
+            self.state.scores[self.players[1]] += 1
+            outcome = "Player 2 wins the round!"
+        if self.state.current_round >= self.state.rounds:
+            p1_score = self.state.scores[self.players[0]]
+            p2_score = self.state.scores[self.players[1]]
+            if p1_score == p2_score:
+                outcome += " Final result: Draw!"
+            elif p1_score > p2_score:
+                outcome += " Final result: Player 1 wins!"
+            else:
+                outcome += " Final result: Player 2 wins!"
+        return outcome
+
+    @staticmethod
+    def determine_winner(c1: str, c2: str) -> int:
+        if c1 == c2:
+            return 0
+        wins = {
+            "rock": "scissors",
+            "paper": "rock",
+            "scissors": "paper",
+        }
+        return 1 if wins[c1] == c2 else 2
+
+
+@dataclass
+class GuessNumberState:
+    secret: int
+    attempts: int
+    max_attempts: int
+
+class GuessNumberGame:
+    """Simple number guessing game."""
+
+    def __init__(self, max_attempts: int = 5):
+        secret = random.randint(1, 100)
+        self.state = GuessNumberState(secret=secret, attempts=0, max_attempts=max_attempts)
+
+    def guess(self, number: int) -> str:
+        self.state.attempts += 1
+        if number == self.state.secret:
+            return "Correct! You've guessed the number."
+        if self.state.attempts >= self.state.max_attempts:
+            return f"Out of attempts! The number was {self.state.secret}."
+        hint = "higher" if number < self.state.secret else "lower"
+        return f"Try {hint}!"
+
+
+@dataclass
+class HangmanState:
+    word: str
+    guesses: set[str]
+    attempts: int
+    max_attempts: int
+
+    def display(self) -> str:
+        return ' '.join(c if c in self.guesses else '_' for c in self.word)
+
+class HangmanGame:
+    WORDS = ['python', 'discord', 'hangman', 'assistant']
+
+    def __init__(self, max_attempts: int = 6):
+        word = random.choice(self.WORDS)
+        self.state = HangmanState(word=word, guesses=set(), attempts=0, max_attempts=max_attempts)
+
+    def guess(self, letter: str) -> str:
+        letter = letter.lower()
+        if letter in self.state.guesses:
+            return 'Already guessed.'
+        self.state.guesses.add(letter)
+        if letter not in self.state.word:
+            self.state.attempts += 1
+        if self.state.attempts >= self.state.max_attempts:
+            return f'Game over! The word was {self.state.word}.'
+        if all(c in self.state.guesses for c in self.state.word):
+            return f'You win! The word was {self.state.word}.'
+        return self.state.display()
+

--- a/bot/logger.py
+++ b/bot/logger.py
@@ -1,0 +1,13 @@
+import datetime
+
+class Logger:
+    """Simple file logger."""
+
+    def __init__(self, filename: str = "bot.log"):
+        self.filename = filename
+
+    def log(self, message: str) -> None:
+        timestamp = datetime.datetime.utcnow().isoformat()
+        with open(self.filename, "a", encoding="utf-8") as f:
+            f.write(f"[{timestamp}] {message}\n")
+

--- a/bot/lstm_model.py
+++ b/bot/lstm_model.py
@@ -1,0 +1,30 @@
+import pickle
+import numpy as np
+from tensorflow import keras
+
+class LSTMModel:
+    """Character-level LSTM language model."""
+    def __init__(self, model_path: str, stoi: dict[str, int], itos: dict[int, str], seq_len: int = 40):
+        self.model = keras.models.load_model(model_path)
+        self.stoi = stoi
+        self.itos = itos
+        self.seq_len = seq_len
+
+    def _encode(self, text: str) -> list[int]:
+        return [self.stoi.get(ch, 0) for ch in text]
+
+    def _decode_token(self, idx: int) -> str:
+        return self.itos.get(idx, '')
+
+    def generate(self, prompt: str, max_tokens: int = 20) -> str:
+        seed = prompt[-self.seq_len:]
+        encoded = self._encode(seed.rjust(self.seq_len))
+        out = list(seed)
+        for _ in range(max_tokens):
+            x = np.array([encoded])
+            preds = self.model.predict(x, verbose=0)[0]
+            idx = int(np.argmax(preds))
+            ch = self._decode_token(idx)
+            out.append(ch)
+            encoded = encoded[1:] + [idx]
+        return ''.join(out)

--- a/bot/markov.py
+++ b/bot/markov.py
@@ -1,0 +1,44 @@
+import pickle
+from collections import defaultdict
+
+class MarkovChain:
+    """Very small word-level Markov chain model."""
+
+    def __init__(self, tokenizer=None):
+        self.model = defaultdict(lambda: defaultdict(int))
+        self.tokenizer = tokenizer
+
+    def train_on_text(self, text: str):
+        tokens = self.tokenizer.encode(text)
+        if len(tokens) < 3:
+            return
+        for a, b, c in zip(tokens, tokens[1:], tokens[2:]):
+            self.model[(a, b)][c] += 1
+
+    def train_pairs(self, pairs: list[tuple[str, str]]):
+        for p, r in pairs:
+            self.train_on_text(p + " " + r)
+
+    def generate(self, prompt: str, max_tokens: int = 20) -> str:
+        tokens = self.tokenizer.encode(prompt)
+        if len(tokens) < 2:
+            tokens = ["", *tokens]
+        out = tokens[:]
+        for _ in range(max_tokens):
+            key = tuple(out[-2:])
+            next_words = self.model.get(key)
+            if not next_words:
+                break
+            # Choose the most common next word
+            next_word = max(next_words.items(), key=lambda x: x[1])[0]
+            out.append(next_word)
+        return self.tokenizer.decode(out)
+
+    def save(self, path: str):
+        with open(path, "wb") as f:
+            pickle.dump(dict(self.model), f)
+
+    def load(self, path: str):
+        with open(path, "rb") as f:
+            data = pickle.load(f)
+        self.model = defaultdict(lambda: defaultdict(int), data)

--- a/bot/memory.py
+++ b/bot/memory.py
@@ -12,6 +12,8 @@ class Memory:
             self.db["cookies"] = {}
         if "rewards" not in self.db:
             self.db["rewards"] = {}
+        if "voices" not in self.db:
+            self.db["voices"] = {}
 
     def close(self):
         self.db.close()
@@ -49,5 +51,13 @@ class Memory:
 
     def add_reward(self, user_id: int, amount: int) -> None:
         self.db["rewards"][user_id] = self.rewards(user_id) + amount
+        self.db.sync()
+
+    # Voice recognition helpers
+    def voice(self, user_id: int):
+        return self.db["voices"].get(user_id)
+
+    def set_voice(self, user_id: int, features) -> None:
+        self.db["voices"][user_id] = features
         self.db.sync()
 

--- a/bot/memory.py
+++ b/bot/memory.py
@@ -14,6 +14,8 @@ class Memory:
             self.db["rewards"] = {}
         if "voices" not in self.db:
             self.db["voices"] = {}
+        if "relationships" not in self.db:
+            self.db["relationships"] = {}
 
     def close(self):
         self.db.close()
@@ -59,5 +61,15 @@ class Memory:
 
     def set_voice(self, user_id: int, features) -> None:
         self.db["voices"][user_id] = features
+        self.db.sync()
+
+    # Relationship helpers
+    def relationship(self, user_id: int, bot_name: str) -> int:
+        rels = self.db["relationships"].setdefault(bot_name, {})
+        return rels.get(user_id, 50)
+
+    def adjust_relationship(self, user_id: int, bot_name: str, delta: int) -> None:
+        rels = self.db["relationships"].setdefault(bot_name, {})
+        rels[user_id] = max(1, min(100, rels.get(user_id, 50) + delta))
         self.db.sync()
 

--- a/bot/memory.py
+++ b/bot/memory.py
@@ -1,0 +1,53 @@
+import shelve
+class Memory:
+    """Persistent memory storage for conversation history and training data."""
+
+    def __init__(self, filename: str = "bot_memory"):
+        self.db = shelve.open(filename, writeback=True)
+        if "history" not in self.db:
+            self.db["history"] = {}
+        if "training" not in self.db:
+            self.db["training"] = {}
+        if "cookies" not in self.db:
+            self.db["cookies"] = {}
+        if "rewards" not in self.db:
+            self.db["rewards"] = {}
+
+    def close(self):
+        self.db.close()
+
+    def history(self, channel_id: int) -> str:
+        return self.db["history"].get(channel_id, "")
+
+    def update_history(self, channel_id: int, entry: str) -> None:
+        hist = self.db["history"].get(channel_id, "") + entry
+        self.db["history"][channel_id] = hist
+        self.db.sync()
+
+    def clear_history(self, channel_id: int) -> None:
+        if channel_id in self.db["history"]:
+            self.db["history"][channel_id] = ""
+            self.db.sync()
+
+    def training(self) -> dict:
+        return self.db["training"]
+
+    def add_training(self, prompt: str, response: str) -> None:
+        self.db["training"][prompt] = response
+        self.db.sync()
+
+    # Cookie and reward helpers
+    def cookies(self, guild_id: int) -> int:
+        return self.db["cookies"].get(guild_id, 0)
+
+    def add_cookies(self, guild_id: int, amount: int) -> None:
+        self.db["cookies"][guild_id] = self.cookies(guild_id) + amount
+        self.db.sync()
+
+    def rewards(self, user_id: int) -> int:
+        return self.db["rewards"].get(user_id, 0)
+
+    def add_reward(self, user_id: int, amount: int) -> None:
+        self.db["rewards"][user_id] = self.rewards(user_id) + amount
+        self.db.sync()
+

--- a/bot/stt.py
+++ b/bot/stt.py
@@ -1,0 +1,32 @@
+import os
+import subprocess
+import tempfile
+import speech_recognition as sr
+
+class SpeechToText:
+    """Transcribe audio files using SpeechRecognition."""
+
+    def __init__(self, lang: str = "en-US"):
+        self.recognizer = sr.Recognizer()
+        self.lang = lang
+
+    def transcribe(self, path: str) -> str:
+        """Return the transcription of the given audio file."""
+        tmp_path = None
+        if not path.lower().endswith(".wav"):
+            tmp_fd, tmp_path = tempfile.mkstemp(suffix=".wav")
+            os.close(tmp_fd)
+            cmd = ["ffmpeg", "-y", "-i", path, tmp_path]
+            subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            use_path = tmp_path
+        else:
+            use_path = path
+        with sr.AudioFile(use_path) as source:
+            audio = self.recognizer.record(source)
+        try:
+            text = self.recognizer.recognize_sphinx(audio, language=self.lang)
+        except Exception:
+            text = ""
+        if tmp_path:
+            os.remove(tmp_path)
+        return text

--- a/bot/tokenizer.py
+++ b/bot/tokenizer.py
@@ -1,0 +1,23 @@
+class SimpleTokenizer:
+    """A very basic whitespace tokenizer.
+
+    This tokenizer splits text into tokens based on whitespace. It
+    includes a minimal interface that can be replaced with a more
+    sophisticated implementation as needed.
+    """
+
+    def encode(self, text: str) -> list[str]:
+        return text.split()
+
+    def decode(self, tokens: list[str]) -> str:
+        return " ".join(tokens)
+
+class CharacterTokenizer:
+    """Tokenize text character by character."""
+
+    def encode(self, text: str) -> list[str]:
+        return list(text)
+
+    def decode(self, tokens: list[str]) -> str:
+        return "".join(tokens)
+

--- a/bot/train_lstm.py
+++ b/bot/train_lstm.py
@@ -1,0 +1,61 @@
+import pickle
+from tensorflow import keras
+from keras.models import Sequential
+from keras.layers import Embedding, LSTM, Dense
+import numpy as np
+from .memory import Memory
+
+MODEL_PATH = 'lstm_model.h5'
+VOCAB_PATH = 'lstm_vocab.pkl'
+SEQ_LEN = 40
+
+
+def load_text() -> str:
+    mem = Memory()
+    pairs = list(mem.training().items())
+    mem.close()
+    text = '\n'.join([p + ' ' + r for p, r in pairs])
+    return text
+
+
+def build_vocab(text: str):
+    chars = sorted(set(text))
+    stoi = {ch: i + 1 for i, ch in enumerate(chars)}  # 0 reserved for padding
+    itos = {i + 1: ch for i, ch in enumerate(chars)}
+    return stoi, itos
+
+
+def vectorize(text: str, stoi: dict[str, int]):
+    dataX, dataY = [], []
+    for i in range(len(text) - SEQ_LEN):
+        seq_in = text[i : i + SEQ_LEN]
+        seq_out = text[i + SEQ_LEN]
+        dataX.append([stoi.get(ch, 0) for ch in seq_in])
+        dataY.append(stoi.get(seq_out, 0))
+    return np.array(dataX), np.array(dataY)
+
+
+def main():
+    text = load_text()
+    if not text:
+        print('No training data found.')
+        return
+    stoi, itos = build_vocab(text)
+    X, y = vectorize(text, stoi)
+    vocab_size = len(stoi) + 1
+
+    model = Sequential([
+        Embedding(vocab_size, 32, input_length=SEQ_LEN),
+        LSTM(64),
+        Dense(vocab_size, activation='softmax'),
+    ])
+    model.compile(loss='sparse_categorical_crossentropy', optimizer='adam')
+    model.fit(X, y, epochs=5, batch_size=64)
+    model.save(MODEL_PATH)
+    with open(VOCAB_PATH, 'wb') as f:
+        pickle.dump((stoi, itos), f)
+    print('Model saved to', MODEL_PATH)
+
+
+if __name__ == '__main__':
+    main()

--- a/bot/train_markov.py
+++ b/bot/train_markov.py
@@ -1,0 +1,18 @@
+from .tokenizer import SimpleTokenizer
+from .memory import Memory
+from .markov import MarkovChain
+
+MODEL_PATH = 'markov_model.pkl'
+
+def main():
+    mem = Memory()
+    tokenizer = SimpleTokenizer()
+    pairs = list(mem.training().items())
+    chain = MarkovChain(tokenizer)
+    chain.train_pairs(pairs)
+    chain.save(MODEL_PATH)
+    mem.close()
+    print(f"Model trained and saved to {MODEL_PATH}")
+
+if __name__ == '__main__':
+    main()

--- a/bot/tts.py
+++ b/bot/tts.py
@@ -1,0 +1,19 @@
+import os
+from gtts import gTTS
+import tempfile
+
+class TextToSpeech:
+    """Generate speech audio from text using gTTS."""
+
+    def __init__(self, lang: str = "en", slow: bool = False):
+        self.lang = lang
+        self.slow = slow
+
+    def speak(self, text: str) -> str:
+        """Convert text to speech and return the audio file path."""
+        tts = gTTS(text=text, lang=self.lang, slow=self.slow)
+        fd, path = tempfile.mkstemp(suffix=".mp3")
+        os.close(fd)
+        tts.save(path)
+        return path
+

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -1,0 +1,13 @@
+import os
+
+def env_bool(name: str, default: bool = False) -> bool:
+    val = os.getenv(name)
+    if val is None:
+        return default
+    return val.lower() in {"1", "true", "yes"}
+
+
+def env_list(name: str, default: str = "") -> list[str]:
+    val = os.getenv(name, default)
+    return [v.strip() for v in val.split(",") if v.strip()]
+

--- a/bot/voice_recognizer.py
+++ b/bot/voice_recognizer.py
@@ -1,0 +1,17 @@
+import librosa
+import numpy as np
+
+class VoiceRecognizer:
+    """Simple voice recognition using MFCC similarity."""
+
+    def __init__(self, n_mfcc: int = 20):
+        self.n_mfcc = n_mfcc
+
+    def extract(self, path: str) -> np.ndarray:
+        y, sr = librosa.load(path, sr=None)
+        mfcc = librosa.feature.mfcc(y=y, sr=sr, n_mfcc=self.n_mfcc)
+        return np.mean(mfcc, axis=1)
+
+    def distance(self, a: np.ndarray, b: np.ndarray) -> float:
+        return np.linalg.norm(a - b)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+discord.py
+gTTS

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ discord.py
 gTTS
 tensorflow
 SpeechRecognition
+librosa
+soundfile

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 discord.py
 gTTS
+tensorflow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 discord.py
 gTTS
 tensorflow
+SpeechRecognition


### PR DESCRIPTION
## Summary
- add example Discord bot that integrates a custom tokenizer
- show how to replace AI backends
- document architecture and usage in README
- clarify dependency instructions for gTTS and ffmpeg

## Testing
- `python -m py_compile bot/tokenizer.py bot/bot.py bot/memory.py bot/games.py bot/tts.py bot/game_ai.py bot/adventure.py bot/dialogue.py bot/logger.py bot/utils.py`


------
https://chatgpt.com/codex/tasks/task_e_683f7957cfe8832c8a33261d80b5590a