### PR TITLE
Add unsupervised and RL training with new commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ extend it with your own ideas.
 ## Future Work
 
 Possible extensions include adding real language model calls, more sophisticated
-game logic, and richer voice synthesis. Contributions are welcome.
+game logic, unsupervised and reinforcement learning, and richer voice synthesis.
+Future versions may integrate with game clients such as **Necto** and
+**Baritone**. Contributions are welcome.
 
 ---
 
@@ -148,6 +150,9 @@ It learns from the same stored conversation pairs and saves a Keras model
 python -m bot.train_lstm
 ```
 
+You can adjust the number of training epochs, embedding size, and LSTM unit
+count using the `--epochs`, `--embed`, and `--units` arguments.
+
 If these files exist the bot will load the LSTM model instead of the Markov
 chain when generating replies.
 
@@ -162,6 +167,27 @@ in any channel the bot can access:
 
 This invokes the same process as running `python -m bot.train_lstm` locally and
 reloads the updated model when finished.
+
+### Training an Autoencoder
+
+You can also train a sequence autoencoder for unsupervised learning:
+
+```bash
+python -m bot.train_autoencoder --epochs 10
+```
+
+Launch the same routine from Discord with `/trainauto`.
+
+### Reinforcement Learning
+
+An experimental Q-learning setup is included for game agents. Train it with:
+
+```bash
+python -m bot.train_rl --episodes 5000
+```
+
+Running `/trainrl` in Discord starts the same process and reloads the Q-table
+when complete.
 
 ## Extensibility
 
@@ -182,7 +208,9 @@ This example demonstrates additional features beyond simple tokenization:
 - **Tic‑Tac‑Toe**: The bot can host a game of tic‑tac‑toe between two users using the `/tictactoe` command.
 - **Rock Paper Scissors**: Challenge the bot with `/rps` and make moves with `/rpsmove`.
 - **History Commands**: Use `/history` to show recent conversation and `/clearhistory` to wipe it.
+- **Memory Summaries**: `/memory` displays a short recap of your latest dialogue.
 - **Voice Chat**: Use `/join` and `/leave` to manage voice connections and `/play` to stream a local file.
+- **Speak Aloud**: `/speak` reads any text in the current voice channel.
 - **Voice Transcription**: Attach an audio file and use `/transcribe` to convert speech to text.
 - **Voice Recognition**: Register your voice with `/registervoice`. When anyone posts an audio attachment the bot automatically compares it against registered samples and announces who it sounds like.
 - **Cookies**: Server owners can gift the bot happiness cookies via `/giftcookies`.
@@ -190,6 +218,8 @@ This example demonstrates additional features beyond simple tokenization:
 - **Relationships**: Each user has a 1-100 relationship score with every bot and can check it via `/relationship`.
 - **Sibling Chat**: Use `/converse` to watch the sibling bots talk to each other for a few rounds. They will also naturally reply to one another when sharing a channel, up to a few messages each time.
 - **Deep Training Command**: Kick off LSTM training from Discord with `/deeptrain`.
+- **Autoencoder Training**: Train an unsupervised model from Discord via `/trainauto`.
+- **Reinforcement Learning**: `/trainrl` launches Q-learning and reloads the table when done.
 - **Language Filter**: The bot allows mild swearing but will replace any blocked terms with `[filtered]`.
 - **Entertaining Personality**: Responses aim to be playful and amusing.
 - **Learning Mode**: The bot stores its replies as training data and even
@@ -240,7 +270,7 @@ Compile the modules to verify there are no syntax errors:
 python -m py_compile \
     bot/tokenizer.py bot/bot.py bot/memory.py bot/games.py \
     bot/tts.py bot/stt.py bot/game_ai.py bot/adventure.py bot/dialogue.py \
-    bot/logger.py bot/utils.py
+    bot/logger.py bot/utils.py bot/train_autoencoder.py bot/train_rl.py
 ```
 
 ## Text-to-Speech and DMs

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -302,7 +302,7 @@ class ChatBot(commands.Cog):
     @commands.command()
     async def help(self, ctx: commands.Context):
         await ctx.send(
-            "Available commands: /ping, /help, /train, /deeptrain, /tictactoe, /move, /rps, /rpsmove, /guessnumber, /guess, /hangman, /hang, /adventure, /adv, /dm, /history, /clearhistory, /giftcookies, /cookies, /rewards, /relationship, /converse, /join, /leave, /play, /transcribe, /registervoice"
+            "Available commands: /ping, /help, /train, /deeptrain, /trainauto, /trainrl, /tictactoe, /move, /rps, /rpsmove, /guessnumber, /guess, /hangman, /hang, /adventure, /adv, /dm, /history, /memory, /clearhistory, /giftcookies, /cookies, /rewards, /relationship, /converse, /join, /leave, /play, /speak, /transcribe, /registervoice"
         )
 
     @commands.command()
@@ -323,6 +323,33 @@ class ChatBot(commands.Cog):
 
         await loop.run_in_executor(None, _run)
         await ctx.send("Deep training complete. New model saved.")
+
+    @commands.command()
+    async def trainauto(self, ctx: commands.Context):
+        """Train the autoencoder model."""
+        await ctx.send("Training autoencoder...")
+        loop = asyncio.get_event_loop()
+
+        def _run():
+            from .train_autoencoder import main as auto_main
+            auto_main()
+
+        await loop.run_in_executor(None, _run)
+        await ctx.send("Autoencoder training finished.")
+
+    @commands.command()
+    async def trainrl(self, ctx: commands.Context):
+        """Run reinforcement learning training."""
+        await ctx.send("Training RL model...")
+        loop = asyncio.get_event_loop()
+
+        def _run():
+            from .train_rl import main as rl_main
+            rl_main()
+
+        await loop.run_in_executor(None, _run)
+        self.game_ai.load_q_table()
+        await ctx.send("RL training complete and Q-table loaded.")
 
     @commands.command()
     async def tictactoe(self, ctx: commands.Context, opponent: discord.Member):
@@ -363,6 +390,12 @@ class ChatBot(commands.Cog):
             await ctx.send("\n".join(entries))
         else:
             await ctx.send("No history.")
+
+    @commands.command()
+    async def memory(self, ctx: commands.Context, limit: int = 5):
+        """Summarize recent dialogue with the user."""
+        summary = self.dialogue.summarize(ctx.author.id)
+        await ctx.send(summary or "No conversation yet.")
 
     @commands.command()
     async def clearhistory(self, ctx: commands.Context):
@@ -593,6 +626,19 @@ class ChatBot(commands.Cog):
         source = discord.FFmpegPCMAudio(file_path)
         vc.play(source)
         await ctx.send(f"Playing {file_path}.")
+
+    @commands.command()
+    async def speak(self, ctx: commands.Context, *, text: str):
+        """Read text aloud in the current voice channel."""
+        vc = self.voice_clients.get(ctx.guild.id)
+        if not vc:
+            await ctx.send("Join a voice channel first with /join.")
+            return
+        path = self.tts.speak(text)
+        if vc.is_playing():
+            vc.stop()
+        vc.play(discord.FFmpegPCMAudio(path), after=lambda e: os.remove(path))
+        await ctx.send(text)
 
     @commands.command()
     async def transcribe(self, ctx: commands.Context):

--- a/bot/game_ai.py
+++ b/bot/game_ai.py
@@ -1,13 +1,53 @@
-class GameAI:
-    """Placeholder for an AI controlling in-game actions."""
+import os
+import pickle
+import random
+import numpy as np
 
-    def __init__(self):
-        # In a real implementation this could load a model or connect to
-        # a separate process that handles complex game logic.
+
+class GameAI:
+    """Simple game AI with optional Q-learning."""
+
+    def __init__(self, q_table_path: str = "q_table.pkl"):
         self.state = {}
+        self.q_table_path = q_table_path
+        self.q_table = {}
+        if os.path.isfile(q_table_path):
+            self.load_q_table(q_table_path)
+
+    def load_q_table(self, path: str | None = None) -> None:
+        """Load a Q-learning table from disk."""
+        use_path = path or self.q_table_path
+        try:
+            with open(use_path, "rb") as f:
+                self.q_table = pickle.load(f)
+        except Exception:
+            self.q_table = {}
+
+    def q_move(self, board: list[str]) -> int:
+        """Choose a move for tic-tac-toe using the Q-table."""
+        key = "".join(board)
+        moves = [i for i, c in enumerate(board) if c == " "]
+        if not moves:
+            return -1
+        qvals = self.q_table.get(key)
+        if qvals is None:
+            return random.choice(moves)
+        best = int(np.argmax(qvals))
+        return best if best in moves else random.choice(moves)
 
     async def decide_action(self, game_state) -> str:
-        """Return a basic action given the current game state."""
-        # This is only a stub demonstrating where you'd put game logic.
+        board = game_state.get("board")
+        if board:
+            move = self.q_move(board)
+            return str(move)
         return "move_forward"
+
+    # Placeholders for advanced integrations
+    def connect_necto(self):
+        """Stub for connecting to a Necto client."""
+        pass
+
+    def connect_baritone(self):
+        """Stub for connecting to a Baritone client."""
+        pass
 

--- a/bot/train_autoencoder.py
+++ b/bot/train_autoencoder.py
@@ -1,12 +1,13 @@
 import pickle
+import numpy as np
 from tensorflow import keras
 from keras.models import Sequential
-from keras.layers import Embedding, LSTM, Dense
-import numpy as np
+from keras.layers import Embedding, LSTM, Dense, RepeatVector, TimeDistributed
+
 from .memory import Memory
 
-MODEL_PATH = 'lstm_model.h5'
-VOCAB_PATH = 'lstm_vocab.pkl'
+MODEL_PATH = 'autoencoder.h5'
+VOCAB_PATH = 'ae_vocab.pkl'
 SEQ_LEN = 40
 
 
@@ -26,42 +27,43 @@ def build_vocab(text: str):
 
 
 def vectorize(text: str, stoi: dict[str, int]):
-    dataX, dataY = [], []
+    dataX = []
     for i in range(len(text) - SEQ_LEN):
         seq_in = text[i : i + SEQ_LEN]
-        seq_out = text[i + SEQ_LEN]
         dataX.append([stoi.get(ch, 0) for ch in seq_in])
-        dataY.append(stoi.get(seq_out, 0))
-    return np.array(dataX), np.array(dataY)
+    X = np.array(dataX)
+    return X
 
 
-def main(epochs: int = 5, embed: int = 32, units: int = 64):
+def main(epochs: int = 10, embed: int = 32, units: int = 64):
     text = load_text()
     if not text:
         print('No training data found.')
         return
     stoi, itos = build_vocab(text)
-    X, y = vectorize(text, stoi)
+    X = vectorize(text, stoi)
     vocab_size = len(stoi) + 1
 
     model = Sequential([
         Embedding(vocab_size, embed, input_length=SEQ_LEN),
         LSTM(units),
-        Dense(vocab_size, activation='softmax'),
+        RepeatVector(SEQ_LEN),
+        LSTM(units, return_sequences=True),
+        TimeDistributed(Dense(vocab_size, activation='softmax')),
     ])
     model.compile(loss='sparse_categorical_crossentropy', optimizer='adam')
+    y = np.expand_dims(X, -1)
     model.fit(X, y, epochs=epochs, batch_size=64)
     model.save(MODEL_PATH)
     with open(VOCAB_PATH, 'wb') as f:
         pickle.dump((stoi, itos), f)
-    print('Model saved to', MODEL_PATH)
+    print('Autoencoder saved to', MODEL_PATH)
 
 
 if __name__ == '__main__':
     import argparse
-
     parser = argparse.ArgumentParser()
-    parser.add_argument('--epochs', type=int, default=5)
+    parser.add_argument('--epochs', type=int, default=10)
     parser.add_argument('--embed', type=int, default=32)
     parser.add_argument('--units', type=int, default=64)
     args = parser.parse_args()

--- a/bot/train_rl.py
+++ b/bot/train_rl.py
@@ -1,0 +1,88 @@
+import pickle
+import random
+import numpy as np
+
+MODEL_PATH = 'q_table.pkl'
+ALPHA = 0.1
+GAMMA = 0.9
+EPSILON = 0.1
+
+
+def check_winner(board):
+    wins = [
+        (0, 1, 2),
+        (3, 4, 5),
+        (6, 7, 8),
+        (0, 3, 6),
+        (1, 4, 7),
+        (2, 5, 8),
+        (0, 4, 8),
+        (2, 4, 6),
+    ]
+    for a, b, c in wins:
+        if board[a] == board[b] == board[c] != ' ':
+            return board[a]
+    return None
+
+
+def available_moves(board):
+    return [i for i, c in enumerate(board) if c == ' ']
+
+
+def board_key(board):
+    return ''.join(board)
+
+
+def choose_move(board, q_table):
+    moves = available_moves(board)
+    if random.random() < EPSILON:
+        return random.choice(moves)
+    key = board_key(board)
+    qvals = q_table.get(key, np.zeros(9))
+    best = max(moves, key=lambda m: qvals[m])
+    return best
+
+
+def main(episodes: int = 5000):
+    q_table = {}
+    for _ in range(episodes):
+        board = [' '] * 9
+        state_key = board_key(board)
+        move = choose_move(board, q_table)
+        prev_key, prev_move = state_key, move
+        mark = 'X'
+        while True:
+            board[move] = mark
+            winner = check_winner(board)
+            if winner or ' ' not in board:
+                reward = 1 if winner == 'X' else 0 if winner is None else -1
+                q_table.setdefault(prev_key, np.zeros(9))
+                q_table[prev_key][prev_move] += ALPHA * (reward - q_table[prev_key][prev_move])
+                break
+            # opponent random move
+            o_move = random.choice(available_moves(board))
+            board[o_move] = 'O'
+            winner = check_winner(board)
+            if winner or ' ' not in board:
+                reward = 1 if winner == 'X' else 0 if winner is None else -1
+                q_table.setdefault(prev_key, np.zeros(9))
+                q_table[prev_key][prev_move] += ALPHA * (reward - q_table[prev_key][prev_move])
+                break
+            next_key = board_key(board)
+            next_move = choose_move(board, q_table)
+            q_table.setdefault(prev_key, np.zeros(9))
+            q_table.setdefault(next_key, np.zeros(9))
+            q_table[prev_key][prev_move] += ALPHA * (GAMMA * np.max(q_table[next_key]) - q_table[prev_key][prev_move])
+            prev_key, prev_move = next_key, next_move
+            move = next_move
+    with open(MODEL_PATH, 'wb') as f:
+        pickle.dump(q_table, f)
+    print('Q-table saved to', MODEL_PATH)
+
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--episodes', type=int, default=5000)
+    args = parser.parse_args()
+    main(args.episodes)


### PR DESCRIPTION
## Summary
- add future work items covering RL/unsupervised learning and game integrations
- document adjustable LSTM training parameters
- add instructions for training autoencoder and RL models
- list new commands and capabilities
- implement `/trainauto`, `/trainrl`, `/memory`, and `/speak` commands
- update GameAI with Q-learning and Necto/Baritone stubs
- provide new training scripts for autoencoder and RL
- allow epochs, embedding, and units for LSTM training

## Testing
- `python -m py_compile \ 
    bot/tokenizer.py bot/bot.py bot/memory.py bot/games.py \ 
    bot/tts.py bot/stt.py bot/game_ai.py bot/adventure.py bot/dialogue.py \ 
    bot/logger.py bot/utils.py bot/train_autoencoder.py bot/train_rl.py bot/train_lstm.py`

------
https://chatgpt.com/codex/tasks/task_e_6842908ee318832c844dc8f0ea653752